### PR TITLE
Hotfix/Hero is selectable flag

### DIFF
--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -25,11 +25,9 @@ class HeroParser:
                     'InDevelopment': hero_value['m_bInDevelopment'],
                     'IsDisabled': hero_value['m_bDisabled'],
                     'IsRecommended': hero_value.get('m_bNewPlayerRecommended', False),
+                    'InHeroLabs': hero_value.get('m_bAvailableInHeroLabs', False),
+                    'IsSelectable': hero_value.get('m_bPlayerSelectable', True),
                 }
-
-                # Key is missing from released heroes
-                # Frontend will need to use if "m_bAvailableInHeroLabs or not m_bInDevelopment"
-                hero_stats['InHeroLabs'] = hero_value.get('m_bAvailableInHeroLabs', False)
 
                 hero_stats.update(
                     self._map_attr_names(hero_value['m_mapStartingStats'], maps.get_hero_attr)


### PR DESCRIPTION
New unreleased hero "Operative" shares all the same flagged values as Trapper, but is "IsSelectable": false. Operative is not actually selectable in game and for the wiki's purposes should remain hidden, this added flag will be used to accomplish this.

Operative currently appears in the hero navbar and takes precedence over Infernus' abilities (of which he shares), causing some conflicts. As such, this is a hotfix rather than a feature.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/38)_