### PR TITLE
Feature/mcginnis rev firerate calc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 decompiled-data
 output-data
+deadlock-data
 venv
 build
 __pycache__

--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -201,11 +201,13 @@ class HeroParser:
         }
 
         if 'm_bSpinsUp' in w and w['m_bSpinsUp'] == 1:
-            weapon_stats.update({
-                'RoundsPerSecondAtMaxSpin': 1 / w['m_flMaxSpinCycleTime'],
-                'SpinAcceleration': w['m_flSpinIncreaseRate'],
-                'SpinDeceleration': w['m_flSpinDecayRate'],
-            })
+            weapon_stats.update(
+                {
+                    'RoundsPerSecondAtMaxSpin': 1 / w['m_flMaxSpinCycleTime'],
+                    'SpinAcceleration': w['m_flSpinIncreaseRate'],
+                    'SpinDeceleration': w['m_flSpinDecayRate'],
+                }
+            )
 
         dps_stats = self._get_dps_stats(weapon_stats)
 
@@ -234,7 +236,9 @@ class HeroParser:
             'ReloadDelay': weapon_stats['ReloadDelay'],
             'ReloadTime': weapon_stats['ReloadTime'],
             'ClipSize': weapon_stats['ClipSize'],
-            'RoundsPerSecond': weapon_stats['RoundsPerSecondAtMaxSpin'] if 'SpinAcceleration' in weapon_stats else weapon_stats['RoundsPerSecond'],
+            'RoundsPerSecond': weapon_stats['RoundsPerSecondAtMaxSpin']
+            if 'SpinAcceleration' in weapon_stats
+            else weapon_stats['RoundsPerSecond'],
             'BurstInterShotInterval': weapon_stats['BurstInterShotInterval'],
             'BulletDamage': weapon_stats['BulletDamage'],
             'BulletsPerShot': weapon_stats['BulletsPerShot'],

--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -200,6 +200,13 @@ class HeroParser:
             #'BulletRadius': w['m_flBulletRadius'] / ENGINE_UNITS_PER_METER,
         }
 
+        if 'm_bSpinsUp' in w and w['m_bSpinsUp'] == 1:
+            weapon_stats.update({
+                'RoundsPerSecondAtMaxSpin': 1 / w['m_flMaxSpinCycleTime'],
+                'SpinAcceleration': w['m_flSpinIncreaseRate'],
+                'SpinDeceleration': w['m_flSpinDecayRate'],
+            })
+
         dps_stats = self._get_dps_stats(weapon_stats)
 
         weapon_stats['DPS'] = self._calc_dps(dps_stats, 'burst')
@@ -227,7 +234,7 @@ class HeroParser:
             'ReloadDelay': weapon_stats['ReloadDelay'],
             'ReloadTime': weapon_stats['ReloadTime'],
             'ClipSize': weapon_stats['ClipSize'],
-            'RoundsPerSecond': weapon_stats['RoundsPerSecond'],
+            'RoundsPerSecond': weapon_stats['RoundsPerSecondAtMaxSpin'] if 'SpinAcceleration' in weapon_stats else weapon_stats['RoundsPerSecond'],
             'BurstInterShotInterval': weapon_stats['BurstInterShotInterval'],
             'BulletDamage': weapon_stats['BulletDamage'],
             'BulletsPerShot': weapon_stats['BulletsPerShot'],
@@ -257,11 +264,13 @@ class HeroParser:
         cycle_time = 1 / d['RoundsPerSecond']
         total_cycle_time = cycle_time + d['BulletsPerBurst'] * d['BurstInterShotInterval']
 
+        # Burst DPS accounts for burst weapons and assumes maximum spinup (if applicable)
         if type == 'burst':
             return (
                 d['BulletDamage'] * d['BulletsPerShot'] * d['BulletsPerBurst'] / (total_cycle_time)
             )
 
+        # Sustained DPS also accounts for reloads/clipsize
         elif type == 'sustained':
             if d['ReloadSingle']:
                 # If reloading 1 bullet at a time, reload time is actually per bullet


### PR DESCRIPTION
McGinnis' weapon "Revs" or "Spins" up, decreasing bullet spread and more importantly, increasing her fire rate. This PR adds proper calculation for the 3 respective attributes, "SpinAcceleration", "SpinDeceleration", and "RoundsPerSecondAtMaxSpin".

Only "RoundsPerSecondAtMaxSpin" is used in dps calculation because the DPS calc assumes already being at max spin.

Uploaded to [[Data:HeroData.json]] and confirmed it works on [[Hero Comparison]] page as expected.

See the commit message regarding deadlock-data in .gitignore

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/46)_