### PR TITLE
citadel_dev localization added

### DIFF
--- a/src/decompiler/decompile.py
+++ b/src/decompiler/decompile.py
@@ -79,7 +79,7 @@ def decompile(DEADLOCK_PATH, WORK_DIR, DECOMPILER_CMD, force=False):
     #   "citadel_patch_notes",
     # ]
 
-    # All folders but voice lines and dev for now
+    # All folders but voice lines for now
     folders = [
         'citadel_attributes',
         'citadel_gc',
@@ -87,6 +87,7 @@ def decompile(DEADLOCK_PATH, WORK_DIR, DECOMPILER_CMD, force=False):
         'citadel_main',
         'citadel_mods',
         'citadel_patch_notes',
+        'citadel_dev',
     ]
 
     # Loop through each folder in the array


### PR DESCRIPTION
Adds `citadel_dev_<lang>` localization files, which includes some WIP localization for hero lab heroes such as kali's role data.

Relevant convo: <https://discord.com/channels/1320176468759941181/1320176469443477525/1321175967124947065>

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/56)_