### PR TITLE
Use new discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ service:
 ## Contributing
 DeadBot is currently early in its development and welcomes new contributors to get involved no matter what level experience you have.
 
-Regularly discussed in the wiki channel on [the Discord server](https://discord.com/invite/jUyhZKwxSW). Ask for access on there if you are interested in contributing.
+Regularly discussed in the wiki channel on [The Deadlock Wiki discord server](https://discord.com/invite/3FJpr53dfu). Ask for access on there if you are interested in contributing.
 
 At the moment the work is fairly ad-hoc, so find me on discord as "HariyoSaag" if you're not sure where to start.


### PR DESCRIPTION
A standalone server was created for the wiki, we can now use this link in the readme instead of the deadlock community discord.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/57)_