### PR TITLE
Bugfix/missing is disabled keys

### DIFF
--- a/input-data/changelogs/changelog_configs.json
+++ b/input-data/changelogs/changelog_configs.json
@@ -394,5 +394,11 @@
         "date": "2024-12-21",
         "link": "https://forums.playdeadlock.com/threads/12-21-2024-update.52206/",
         "is_hero_lab": false
+    },
+    "2024-12-31": {
+        "forum_id": "52769",
+        "date": "2024-12-31",
+        "link": "https://forums.playdeadlock.com/threads/12-31-2024.52769/",
+        "is_hero_lab": false
     }
 }

--- a/input-data/changelogs/raw/2024-12-31.txt
+++ b/input-data/changelogs/raw/2024-12-31.txt
@@ -1,0 +1,19 @@
+- Rapid Recharge: Charge Time reduced from -60% to -45%
+- Rapid Recharge: Weapon Power increased from 12% to 18%
+- Yamato: Bullet damage growth reduced from 0.35 to 0.33
+- Yamato: Shadow Transformation cooldown increased from 85s to 100s
+- Mirage: Fire Scarabs base damage reduced from 90 to 75
+- Infernus: Flame Dash cooldown increased from 35s to 38s
+- Infernus: Flame Dash spirit scaling increased from 0.7 to 0.8
+- Infernus: Flame Dash T2 reduced from +45 to +40
+- Infernus: Flame Dash T3 Charge Time increased from 18s to 20s
+- Kelvin: Base Spirit Resistance increased from 10% to 15%
+- Kelvin: Ice Path cooldown increased from 42s to 46s
+- Warden: Base bullet damage reduced from 19.8 to 19.5
+- Warden: Last Stand base DPS reduced from 100 to 90
+- Warden: Last Stand DPS spirit power scaling increased from 1.2 to 1.4
+- Vindicta: Bullet Velocity reduced from 889 to 810
+- Vindicta: Assassinate T2 reduced from +130 to +120
+- Vindicta: Assassinate Charge Time increased from 2s to 2.5s
+- Shiv: Bullet growth reduced from +0.31 to +0.27
+- Shiv: Serrated Knives T3 increased from +5 Bleed DPS to +7

--- a/src/parser/parsers/abilities.py
+++ b/src/parser/parsers/abilities.py
@@ -26,7 +26,7 @@ class AbilityParser:
             ability_data = {
                 'Key': ability_key,
                 'Name': self.localizations.get(ability_key, None),
-                'IsDisabled': ability.get('m_bDisabled', None),
+                'IsDisabled': ability.get('m_bDisabled', False),
             }
 
             stats = ability['m_mapAbilityProperties']

--- a/src/parser/parsers/abilities.py
+++ b/src/parser/parsers/abilities.py
@@ -26,6 +26,7 @@ class AbilityParser:
             ability_data = {
                 'Key': ability_key,
                 'Name': self.localizations.get(ability_key, None),
+                'IsDisabled': ability.get('m_bIsDisabled', False),
             }
 
             stats = ability['m_mapAbilityProperties']

--- a/src/parser/parsers/abilities.py
+++ b/src/parser/parsers/abilities.py
@@ -26,7 +26,7 @@ class AbilityParser:
             ability_data = {
                 'Key': ability_key,
                 'Name': self.localizations.get(ability_key, None),
-                'IsDisabled': ability.get('m_bIsDisabled', True),
+                'IsDisabled': ability.get('m_bDisabled', None),
             }
 
             stats = ability['m_mapAbilityProperties']

--- a/src/parser/parsers/abilities.py
+++ b/src/parser/parsers/abilities.py
@@ -26,7 +26,7 @@ class AbilityParser:
             ability_data = {
                 'Key': ability_key,
                 'Name': self.localizations.get(ability_key, None),
-                'IsDisabled': ability.get('m_bIsDisabled', False),
+                'IsDisabled': ability.get('m_bIsDisabled', True),
             }
 
             stats = ability['m_mapAbilityProperties']

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -104,7 +104,7 @@ class ItemParser:
         return parsed_item_data
 
     def _is_disabled(self, item):
-        is_disabled = False
+        is_disabled = True
         if 'm_bDisabled' in item:
             flag = item['m_bDisabled']
             # flag is 1 of [True, False, 'true', 'false']

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -104,7 +104,7 @@ class ItemParser:
         return parsed_item_data
 
     def _is_disabled(self, item):
-        is_disabled = True
+        is_disabled = None
         if 'm_bDisabled' in item:
             flag = item['m_bDisabled']
             # flag is 1 of [True, False, 'true', 'false']

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -75,14 +75,14 @@ class ItemParser:
             # 'ImagePath': str(item_value.get('m_strAbilityImage', None)),
             'TargetTypes': target_types,
             'ShopFilters': shop_filters,
-            'Disabled': self._is_disabled(item_value),
+            'IsDisabled': self._is_disabled(item_value),
         }
 
         for attr_key in item_ability_attrs.keys():
             parsed_item_data[attr_key] = item_ability_attrs[attr_key]['m_strValue']
 
         # ignore description formatting for disabled items
-        if not parsed_item_data['Disabled']:
+        if not parsed_item_data['IsDisabled']:
             description = self.localizations.get(key + '_desc')
             parsed_item_data['Description'] = string_utils.format_description(
                 description, parsed_item_data, maps.KEYBIND_MAP
@@ -139,6 +139,3 @@ class ItemParser:
 
         return output_array
 
-
-def is_enabled(item):
-    return not item.get('Disabled', False)

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -104,7 +104,7 @@ class ItemParser:
         return parsed_item_data
 
     def _is_disabled(self, item):
-        is_disabled = None
+        is_disabled = False
         if 'm_bDisabled' in item:
             flag = item['m_bDisabled']
             # flag is 1 of [True, False, 'true', 'false']

--- a/src/utils/parameters.py
+++ b/src/utils/parameters.py
@@ -1,5 +1,7 @@
 import os
 import argparse
+from dotenv import load_dotenv
+load_dotenv()
 
 ARG_PARSER = argparse.ArgumentParser(
     prog='DeadBot',


### PR DESCRIPTION
- Addresses #63 
- Parses m_bDisabled to IsDisabled for Ability Data (independent to Ability Card parsing)

This standardization will then be used by the new deadlock-wiki/pages repository.

I tested it locally and got IsDisabled key seen on ability-data.json output data

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/62)_