### PR TITLE
added support for the new keybind and inline attribute localization strings

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -150,22 +150,6 @@ def get_bound_abilities(value):
     return parts[2]
 
 
-KEYBIND_MAP = {
-    'iv_attack': '{{Mouse|1}}',
-    'iv_attack2': '{{Mouse|2}}',
-    'key_alt_cast': '{{Mouse|3}}',
-    'key_reload': 'R',
-    'key_innate_1': 'Shift',
-    'in_mantle': 'Space',
-    'key_duck': 'Ctrl',
-    'in_ability1': '1',
-    'in_ability2': '2',
-    'in_ability3': '3',
-    'in_ability4': '4',
-    'in_move_down': 'Down',
-    'key_forward': 'Forward',
-}
-
 LOCALIZATION_OVERRIDE_MAP = {
     'MaxChargeDuration': 'SpeedBoostDuration',
 }

--- a/src/parser/parsers/ability_cards.py
+++ b/src/parser/parsers/ability_cards.py
@@ -51,8 +51,18 @@ class AbilityCardsParser:
                     if parsed_ui is not None:
                         hero_abilities[self.ability_index] = parsed_ui
                 except Exception as e:
-                    logger.error(f'Failed to parse ui for ability {ability["Key"]}')
-                    raise e
+                    # only exit the parser for a supported wiki language
+                    if self.language in ['english', 'russian']:
+                        logger.error(
+                            f'Failed to parse ui for ability {ability["Key"]} for'
+                            f'language {self.language}'
+                        )
+                        raise e
+                    else:
+                        logger.warning(
+                            f'Failed to parse ui for ability {ability["Key"]} for'
+                            f'language {self.language}'
+                        )
 
             output[self.hero_key] = hero_abilities
 
@@ -74,9 +84,9 @@ class AbilityCardsParser:
             # required variables to insert into the description
             format_vars = (
                 self.ability,
-                maps.KEYBIND_MAP,
                 {'ability_key': self.ability_index},
                 {'hero_name': self._get_localized_string(self.hero_key)},
+                self.localizations[self.language],
             )
             ability_desc = string_utils.format_description(ability_desc, *format_vars)
             parsed_ui['DescKey'] = ability_desc_key
@@ -132,9 +142,9 @@ class AbilityCardsParser:
                     # required variables to insert into the description
                     format_vars = (
                         self.ability,
-                        maps.KEYBIND_MAP,
                         {'ability_key': self.ability_index},
                         {'hero_name': self._get_localized_string(self.hero_key)},
+                        self.localizations[self.language],
                     )
                     parsed_info_section['DescKey'] = desc_key
 
@@ -473,9 +483,9 @@ class AbilityCardsParser:
         format_vars = (
             overrides,
             data,
-            maps.KEYBIND_MAP,
             {'ability_key': self.ability_index},
             {'hero_name': self._get_localized_string(self.hero_key)},
+            self.localizations[self.language],
         )
 
         formatted_desc = string_utils.format_description(desc, *format_vars)

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -88,7 +88,7 @@ class ItemParser:
         if not parsed_item_data['IsDisabled']:
             description = self.localizations.get(key + '_desc')
             parsed_item_data['Description'] = string_utils.format_description(
-                description, parsed_item_data, maps.KEYBIND_MAP
+                description, parsed_item_data, self.localizations
             )
         else:
             description = self.localizations.get(key + '_desc')

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -43,6 +43,14 @@ def format_description(description, *data_sets):
     description = re.sub(r'<Panel\b[^>]*>', '', description)
     description = description.replace('</Panel>', '')
 
+    # keybind icons are formatted as {g:citadel_keybind:<key_name>}
+    description = re.sub(r"\{g:citadel_keybind:'([^']+)'\}", _replace_keybind, description)
+
+    # attribute labels are formatted as {g:citadel_inline_attribute:<key_name>}
+    description = re.sub(
+        r"\{g:citadel_inline_attribute:'([^']+)'\}", make_replace_inline_attribute(data), description
+    )
+
     return _replace_variables(description, data)
 
 
@@ -81,6 +89,45 @@ IGNORE_KEYS = [
     'DisarmDuration',
     '​ไซเลนเซอร์​adius',
 ]
+
+KEYBIND_MAP = {
+    'Attack': '{{Mouse|1}}',
+    'ADS': '{{Mouse|2}}',
+    'AltCast': '{{Mouse|3}}',
+    'Reload': 'R',
+    'Roll': 'Shift',
+    'Mantle': 'Space',
+    'Crouch': 'Ctrl',
+    'Ability1': '1',
+    'Ability2': '2',
+    'Ability3': '3',
+    'Ability4': '4',
+    'MoveDown': 'Down',
+    'MoveForward': 'Forward',
+}
+
+
+def _replace_keybind(match):
+    key = match.group(1)
+    replace_string = KEYBIND_MAP.get(key)
+
+    if replace_string is None:
+        raise Exception(f'Missing keybind map for {key}')
+
+    return replace_string
+
+
+def make_replace_inline_attribute(data):
+    def replace_inline_attribute(match):
+        key = match.group(1)
+
+        attr_label = data.get('InlineAttribute_' + key)
+        if attr_label is None:
+            raise Exception(f'Missing inline map for {key}')
+
+        return attr_label
+
+    return replace_inline_attribute
 
 
 # format description with data. eg. "When you are above {s:LifeThreshold}% health"


### PR DESCRIPTION
As of patch on 8th May, they have revamped the keybind and inline attribute strings to use {g:...} instead of the {s:...} tags

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/66)_