### PR TITLE
feat: Expand NPC stat parsing and fix data corruption

### DIFF
--- a/src/decompiler/kv3_to_json.py
+++ b/src/decompiler/kv3_to_json.py
@@ -40,12 +40,17 @@ def kv3_to_json(kv3_obj, output_file):
 
 # Removes subclass features from kv3 file and writes to json
 def remove_subclass(path):
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         content = f.read()
-        # subclass features in kv3 don't seem to be supported in the keyvalues3 python library
-        content = content.replace('subclass:', '')
+    
+    # 1. Fix the non-standard "subclass:" syntax by simply removing it.
+    content = content.replace('subclass:', '')
+    
+    # 2. Fix the data corruption bug by replacing the problematic empty resource 
+    #    with a standard empty string before the parser sees it.
+    content = content.replace('resource_name:""', '""')
 
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(content)
 
 

--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -365,12 +365,12 @@ class NpcParser:
 
             if script_values and isinstance(script_values, list) and len(script_values) >= 3:
                 stats['BonusMaxHealth'] = num_utils.assert_number(
-                    script_values[REJUV_HEALTH_INDEX]
+                    script_values[REJUV_HEALTH_INDEX].get('m_value')
                 )
                 stats['BonusFireRate'] = num_utils.assert_number(
-                    script_values[REJUV_FIRERATE_INDEX]
+                    script_values[REJUV_FIRERATE_INDEX].get('m_value')
                 )
                 stats['BonusSpiritDamage'] = num_utils.assert_number(
-                    script_values[REJUV_SPIRIT_DMG_INDEX]
+                    script_values[REJUV_SPIRIT_DMG_INDEX].get('m_value')
                 )
         return stats

--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -147,15 +147,22 @@ class NpcParser:
     # --- Objective & Boss Parsers ---
 
     def _parse_guardian(self, data):
-        return {
+        stats = {
             'MaxHealth': self._read_value(data, 'm_nMaxHealth'),
             'PlayerDPS': self._read_value(data, 'm_flPlayerDPS'),
             'TrooperDPS': self._read_value(data, 'm_flTrooperDPS'),
+            'MeleeDamage': self._read_value(data, 'm_flMeleeDamage'),
+            'MeleeAttemptRange': self._read_value(data, 'm_flMeleeAttemptRange'),
             'InvulnerabilityRange': self._read_value(data, 'm_flInvulRange'),
             'PlayerDamageResistance': self._read_value(data, 'm_flPlayerDamageResistPct'),
             'TrooperDamageResistanceBase': self._read_value(data, 'm_flT1BossDPSBaseResist'),
             'TrooperDamageResistanceMax': self._read_value(data, 'm_flT1BossDPSMaxResist'),
+            'TrooperDamageResistanceRampUpTime': self._read_value(
+                data, 'm_flT1BossDPSMaxResistTimeInSeconds'
+            ),
         }
+        stats.update(self._parse_intrinsic_modifiers(data))
+        return stats
 
     def _parse_base_guardian(self, data):
         stats = self._parse_guardian(data)
@@ -274,11 +281,19 @@ class NpcParser:
         stats = {
             'MaxHealthPhase1': self._read_value(data, 'm_nMaxHealth'),
             'MaxHealthPhase2': self._read_value(data, 'm_nPhase2Health'),
+            'SightRangePlayers': self._read_value(data, 'm_flSightRangePlayers'),
             'LaserDPSToPlayers': self._read_value(data, 'm_flLaserDPSToPlayers'),
+            'LaserDPSToNPCs': self._read_value(data, 'm_flLaserDPSToNPCs'),
             'LaserDPSMaxHealthPercent': self._read_value(data, 'm_flLaserDPSMaxHealth'),
             'IsUnkillableInPhase1': 'm_Phase1Modifier' in data,
-            'HealthGrowthPerMinute': self._read_value(
+            'HealthGrowthPerMinutePhase1': self._read_value(
                 data, 'm_ObjectiveHealthGrowthPhase1', 'm_iGrowthPerMinute'
+            ),
+            'HealthGrowthPerMinutePhase2': self._read_value(
+                data, 'm_ObjectiveHealthGrowthPhase2', 'm_iGrowthPerMinute'
+            ),
+            'OutOfCombatHealthRegen': self._read_value(
+                data, 'm_ObjectiveRegen', 'm_flOutOfCombatHealthRegen'
             ),
             'RangedResistanceMinRange': self._read_value(
                 data, 'm_RangedArmorModifier', 'm_flRangeMin'


### PR DESCRIPTION
*   Adds a significant number of new stats for the Guardian, Walker, and Patron bosses.
*   Fixes a decompiler bug that caused `neutral_trooper_strong` to lose its resistance stats.
*   Refactors intrinsic modifier parsing into a shared helper method to reduce code duplication.
*   Adds parsing for the Weakened Walker and corrects a bug in the Rejuvenator parser.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/84)_