### PR TITLE
fix: add typo map to ability cards

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -154,6 +154,9 @@ def get_bound_abilities(value):
 LOCALIZATION_OVERRIDE_MAP = {
     'MaxChargeDuration': 'SpeedBoostDuration',
     'MinDPS': 'MinDps',
+    'BulletVulnerbility': 'BulletVulnerability',
+    'DebuffDuration': 'Duration',
+    'EspejismoDjinnsMarkMaxStacks': 'DjinnsMarkMaxStacks',
 }
 
 

--- a/src/parser/parsers/ability_cards.py
+++ b/src/parser/parsers/ability_cards.py
@@ -488,6 +488,7 @@ class AbilityCardsParser:
         format_vars = (
             overrides,
             format_data,
+            self.ability,
             {'ability_key': self.ability_index},
             {'hero_name': self.hero['Name']},
             self.localizations[self.language],


### PR DESCRIPTION


_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/85)_