### PR TITLE
fix: added weapon burst consideration to rounds per second calculation

### DIFF
--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -1,7 +1,6 @@
 import parser.maps as maps
 import utils.json_utils as json_utils
-from utils.num_utils import convert_engine_units_to_meters
-from utils.num_utils import round_sig_figs
+from utils.num_utils import convert_engine_units_to_meters, round_sig_figs
 
 
 class HeroParser:
@@ -351,8 +350,7 @@ class HeroParser:
         # Burst DPS accounts for burst weapons and assumes maximum spinup (if applicable)
         if type == 'burst':
             dps = stats.get('BulletDamage', 0) * bullets_per_shot * stats.get('BulletsPerBurst', 1) / total_cycle_time
-            # Clean floating-point artifacts by formatting to a string with 4 decimal places and re-casting to float.
-            return float(f'{dps:.4f}')
+            return dps
 
         # Sustained DPS also accounts for reloads/clipsize
         elif type == 'sustained':
@@ -360,8 +358,7 @@ class HeroParser:
             if clip_size == 0:
                 # For weapons with no clip (like Bebop's beam), sustained DPS is the same as burst DPS
                 sustained_dps = stats.get('BulletDamage', 0) * bullets_per_shot * stats.get('BulletsPerBurst', 1) / total_cycle_time
-                # Clean floating-point artifacts by formatting to a string with 4 decimal places and re-casting to float.
-                return float(f'{sustained_dps:.4f}')
+                return sustained_dps
 
             # All reload actions have ReloadDelay played first,
             # but typically only single bullet reloads have a non-zero delay
@@ -381,8 +378,7 @@ class HeroParser:
                 return 0
 
             sustained_dps = damage_from_clip / total_time
-            # Clean floating-point artifacts by formatting to a string with 4 decimal places and re-casting to float.
-            return float(f'{sustained_dps:.4f}')
+            return sustained_dps
 
         else:
             raise Exception('Invalid DPS type, must be one of: ' + ', '.join(['burst', 'sustained']))
@@ -402,7 +398,7 @@ class HeroParser:
         scaled_dps = self._calc_dps(dps_stats_scaled, type)
         dps = self._calc_dps(dps_stats, type)
 
-        return round(scaled_dps - dps, 4)
+        return round_sig_figs(scaled_dps - dps, 5)
 
     def _parse_spirit_scaling(self, hero_value):
         if 'm_mapScalingStats' not in hero_value:

--- a/src/utils/num_utils.py
+++ b/src/utils/num_utils.py
@@ -2,14 +2,14 @@ import math
 from constants import ENGINE_UNITS_PER_METER
 
 
-def convert_engine_units_to_meters(engine_units: float, decimal_places: int = 2) -> float:
+def convert_engine_units_to_meters(engine_units: int | float, sigfigs: int = 4) -> float:
     """
     Convert engine units to meters with proper precision handling.
     Eliminates floating-point artifacts by rounding to a reasonable precision.
 
     Args:
         engine_units: Raw value in engine units
-        decimal_places: Number of decimal places to round to (default: 2)
+        sigfigs: Number of significant figures to round to (default: 4)
 
     Returns:
         Value in meters, rounded and cleaned of floating-point artifacts
@@ -18,8 +18,8 @@ def convert_engine_units_to_meters(engine_units: float, decimal_places: int = 2)
         return engine_units
 
     meters = engine_units / ENGINE_UNITS_PER_METER
-    # Round to specified decimal places to avoid floating-point precision artifacts
-    return round(meters, decimal_places)
+    # Round to specified significant figures to avoid floating-point precision artifacts
+    return round_sig_figs(meters, sigfigs)
 
 
 def assert_number(value):
@@ -80,6 +80,10 @@ def is_zero(value):
 
 
 def round_sig_figs(value: float | int, sigfigs: int):
+    if value == 0.0:
+        return 0.0
+
     if value == 0:
         return 0
+
     return round(value, sigfigs - int(math.floor(math.log10(abs(value)))) - 1)


### PR DESCRIPTION
- Fixed calculation of rounds per second
- Added use of significant figures rounding as decimal places does not accurately represent precision. Eg. values less than 1 can be too aggressively rounded

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/133) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_