### PR TITLE
fix: extracted tiered Walker health, backdoor range and stomp trooper rate

### DIFF
--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -298,9 +298,11 @@ class NpcParser:
             'PlayerInitialSightRange': convert_engine_units_to_meters(json_utils.read_value(data, 'm_flPlayerInitialSightRange')),
             'StompDamage': json_utils.read_value(data, 'm_flStompDamage'),
             'StompDamageMaxHealthPercent': json_utils.read_value(data, 'm_flStompDamageMaxHealthPercent'),
+            'StompDamageTrooperRate': json_utils.read_value(data, 'm_flStompDamageTrooperRate'),
             'StompRadius': convert_engine_units_to_meters(json_utils.read_value(data, 'm_flStompImpactRadius')),
             'StompStunDuration': json_utils.read_value(data, 'm_flStunDuration'),
             'StompKnockup': json_utils.read_value(data, 'm_flStompTossUpMagnitude'),
+            'BackdoorProtectionRange': convert_engine_units_to_meters(json_utils.read_value(data, 'm_flBackDoorProtectionRange')),
             'InvulnerabilityRange': convert_engine_units_to_meters(invuln_range_raw),
             'BoundAbilities': self._parse_npc_abilities(data.get('m_mapBoundAbilities')),
         }


### PR DESCRIPTION
Updates the `NpcParser` to handle the new Walker data structure. Instead of a single health value, the parser now extracts `MaxHealthLevel1`, `MaxHealthLevel2`, and `MaxHealthLevel3` by reading the base `m_nMaxHealth` and the new `m_EmpoweredModifierLevel` subclasses.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/139) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_