### PR TITLE
fix: removed russian from supported languages to prevent bad deployments

### DIFF
--- a/src/parser/parsers/ability_cards.py
+++ b/src/parser/parsers/ability_cards.py
@@ -2,7 +2,7 @@ from utils import num_utils
 import utils.string_utils as string_utils
 from loguru import logger
 
-SUPPORTED_LANGS = ['english', 'russian']
+SUPPORTED_LANGS = ['english']
 
 
 class AbilityCardsParser:


### PR DESCRIPTION
Russian is not a crucial language to publish to the wiki. With how Valve frequently release language updates for english first, this can halt deployments of new versions

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/176) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_