### PR TITLE
fix: use 'spirit' as default scaling type for ability upgrades

### DIFF
--- a/src/parser/parsers/ability_cards.py
+++ b/src/parser/parsers/ability_cards.py
@@ -277,9 +277,8 @@ class AbilityCardsParser:
             else:
                 prop_object['Value'] = prop_value
 
-            attr_type = self._get_raw_ability_attr(prop).get('m_strCSSClass')
-            if attr_type is not None:
-                prop_object['Type'] = attr_type
+            attr_type = self._get_raw_ability_attr(prop).get('m_strCSSClass') or 'spirit'
+            prop_object['Type'] = attr_type
 
             alt_block.append(prop_object)
 
@@ -324,9 +323,8 @@ class AbilityCardsParser:
             else:
                 data['Value'] = prop_value
 
-            attr_type = raw_attr.get('m_strCSSClass')
-            if attr_type is not None:
-                data['Type'] = attr_type
+            attr_type = raw_attr.get('m_strCSSClass') or 'spirit'
+            data['Type'] = attr_type
 
             # These props are directly referenced and should live on the top level
             if prop in [


### PR DESCRIPTION
Fixes #255

Implements the fix suggested by @NimrodLev in issue comments: default to 'spirit' scaling type when `m_strCSSClass` is null for ability upgrade attributes.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/178) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_