### PR TITLE
fix: default upgrade scale type to spirit when not specified

### DIFF
--- a/src/parser/parsers/abilities.py
+++ b/src/parser/parsers/abilities.py
@@ -107,9 +107,15 @@ class AbilityParser:
                         parsed_upgrade_set[prop]['Value'] = value
 
                 elif upgrade_type in ['EAddToScale', 'EMultiplyScale']:
-                    # Default to ETechPower/spirit if no scale type specified
+                    # If no explicit scale type, look up from the base property
                     if scale_type is None:
-                        scale_type = 'ETechPower'
+                        base_stat = json_utils.deep_get(ability, 'm_mapAbilityProperties', prop)
+                        if base_stat and 'm_subclassScaleFunction' in base_stat:
+                            scale_func = base_stat['m_subclassScaleFunction']
+                            scale_type = scale_func.get('m_eSpecificStatScaleType')
+                            # Infer from scale function class if no specific type
+                            if scale_type is None and 'tech' in scale_func.get('_class', ''):
+                                scale_type = 'ETechPower'
                     parsed_upgrade_set[prop] = {
                         'Value': parsed_upgrade_set.get(prop, 0),
                         'Scale': {


### PR DESCRIPTION
Use base property's scale type for upgrades when `m_eScaleStatFilter` is not specified. Looks up `m_eSpecificStatScaleType` from the base property's scale function, or infers from the class name for tech-related functions. This ensures Scale.Type is never null for EAddToScale/EMultiplyScale upgrade types.

Fixes #255

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/180) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_