### PR TITLE
fix: filter out empty WeaponInfo from NPC abilities

### DIFF
--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -274,6 +274,10 @@ class NpcParser:
             if not isinstance(parsed_ability, dict):
                 parsed_ability = {}
 
+            # Only keep WeaponInfo for actual weapon slots
+            if slot != 'ESlot_Weapon_Primary' and 'WeaponInfo' in parsed_ability:
+                del parsed_ability['WeaponInfo']
+
             # Ensure key metadata is present
             parsed_ability['Key'] = ability_key
             parsed_ability['Name'] = self.localizations.get(ability_key, ability_key)


### PR DESCRIPTION
NPC abilities (like Walker rocket barrage) were showing empty WeaponInfo blocks with null/placeholder damage values, while the real damage was in AbilityProperties. This was messy data that wasn't needed.

Now only `ESlot_Weapon_Primary` retains WeaponInfo. All other ability slots have it removed.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/184) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_