### PR TITLE
fix: upload item-cards.json file to wiki

### DIFF
--- a/src/wiki/pages.py
+++ b/src/wiki/pages.py
@@ -8,6 +8,7 @@ DATA_PAGE_FILE_MAP = {
     'HeroData.json': 'json/hero-data.json',
     'HeroMeaningfulStats.json': 'json/hero-meaningful-stats.json',
     'ItemData.json': 'json/item-data.json',
+    'ItemCards.json': 'json/item-cards.json',
     'NpcData.json': 'json/npc-data.json',
     'Lang bg.json': 'localizations/bulgarian.json',
     'Lang cs.json': 'localizations/czech.json',


### PR DESCRIPTION


_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/186) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_