### PR TITLE
ci: remove \r strings from commit message as it breaks deadlock-data notification

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -179,10 +179,10 @@ jobs:
           DEADBOT_VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/version *= *"\(.*\)"/\1/')
           echo "deadbot=$DEADBOT_VERSION" >> $GITHUB_OUTPUT
           
-          DEADLOCK_VERSION=$(grep '^ClientVersion=' "./decompiled-data/version.txt" | cut -d'=' -f2)
+          DEADLOCK_VERSION=$(grep '^ClientVersion=' "./decompiled-data/version.txt" | cut -d'=' -f2 | tr -d '\r')
           echo "deadlock=$DEADLOCK_VERSION" >> $GITHUB_OUTPUT
 
-          DATE=$(grep '^VersionDate=' "./decompiled-data/version.txt" | cut -d'=' -f2)
+          DATE=$(grep '^VersionDate=' "./decompiled-data/version.txt" | cut -d'=' -f2 | tr -d '\r')
           echo "date=$DATE" >> $GITHUB_OUTPUT
           
       - name: Commit and push input-data changes to deadbot


### PR DESCRIPTION


_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/201) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_