### PR TITLE
fix: ignore unused reload delay & burst interval

### DIFF
--- a/src/parser/parsers/weapon_parser.py
+++ b/src/parser/parsers/weapon_parser.py
@@ -150,6 +150,10 @@ def calculate_fire_rate(weapon_info: Dict[str, Any]) -> float:
     intra_burst_cd = weapon_info.get('m_flIntraBurstCycleTime', 0)
     bullets_per_shot = weapon_info.get('m_iBurstShotCount', 0)
 
+    # Only use intra‑burst delay if the weapon actually fires multiple shots per burst
+    if bullets_per_shot <= 1:
+        intra_burst_cd = 0
+
     total_shot_time = bullets_per_shot * intra_burst_cd + shot_cd + burst_cd
 
     return bullets_per_shot / total_shot_time if total_shot_time > 0 else 0

--- a/src/parser/parsers/weapon_parser.py
+++ b/src/parser/parsers/weapon_parser.py
@@ -16,7 +16,7 @@ def parse_weapon_info(weapon_info: Dict[str, Any]) -> Dict[str, Any]:
     stats['ClipSize'] = weapon_info.get('m_iClipSize')
     stats['ReloadTime'] = weapon_info.get('m_reloadDuration')
     stats['ReloadMovespeed'] = float(weapon_info.get('m_flReloadMoveSpeed', '0')) / 10000
-    stats['ReloadDelay'] = weapon_info.get('m_flReloadSingleBulletsInitialDelay', 0)
+    stats['ReloadDelay'] = weapon_info.get('m_flReloadSingleBulletsInitialDelay', 0) if weapon_info.get('m_bReloadSingleBullets') else 0
     stats['ReloadSingle'] = weapon_info.get('m_bReloadSingleBullets', False)
 
     # Falloff and Range

--- a/src/parser/parsers/weapon_parser.py
+++ b/src/parser/parsers/weapon_parser.py
@@ -16,7 +16,7 @@ def parse_weapon_info(weapon_info: Dict[str, Any]) -> Dict[str, Any]:
     stats['ClipSize'] = weapon_info.get('m_iClipSize')
     stats['ReloadTime'] = weapon_info.get('m_reloadDuration')
     stats['ReloadMovespeed'] = float(weapon_info.get('m_flReloadMoveSpeed', '0')) / 10000
-    stats['ReloadDelay'] = weapon_info.get('m_flReloadSingleBulletsInitialDelay', 0) if weapon_info.get('m_bReloadSingleBullets') else 0
+    stats['ReloadDelay'] = weapon_info.get('m_flReloadSingleBulletsInitialDelay', 0.0) if weapon_info.get('m_bReloadSingleBullets') else 0.0
     stats['ReloadSingle'] = weapon_info.get('m_bReloadSingleBullets', False)
 
     # Falloff and Range


### PR DESCRIPTION
Mina's raw weapon data has `m_flReloadSingleBulletsInitialDelay` set to 0.4 even though she doesn't use single‑bullet reloads. Every other non‑single‑bullet weapon has this at 0.

Made it so we only pass the delay along when `m_bReloadSingleBullets` is true.

Additional fix: Doorman and Paige both had a BurstInterShotInterval value in the raw game files even though they fire one shot per click (m_iBurstShotCount = 1). Now we only include BurstInterShotInterval when the weapon truly fires multiple shots per burst.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/204) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_