### PR TITLE
Fix: duplicate patch sections in changelog append

### DIFF
--- a/src/changelogs/fetch_changelogs.py
+++ b/src/changelogs/fetch_changelogs.py
@@ -489,7 +489,8 @@ class ChangelogFetcher:
                 entry_text = re.sub(r'=== Patch \d+ ===\n*', '', entry_text).strip()
 
                 # Skip if this content is already in final_text (prevents duplicates)
-                if entry_text not in final_text:
+                normalized_entry = re.sub(r'^- ', '* ', entry_text, flags=re.MULTILINE)
+                if entry_text not in final_text and normalized_entry not in final_text:
                     patch_num = get_next_patch_num(final_text)
                     final_text += f'\n\n=== Patch {patch_num} ===\n\n{entry_text}'
                     logger.debug(f'Adding Patch {patch_num} to {date_key}')

--- a/src/changelogs/fetch_changelogs.py
+++ b/src/changelogs/fetch_changelogs.py
@@ -488,9 +488,10 @@ class ChangelogFetcher:
                 entry_text = entry['text']
                 entry_text = re.sub(r'=== Patch \d+ ===\n*', '', entry_text).strip()
 
-                # Skip if this content is already in final_text (prevents duplicates)
+                # Skip if this content is already in final_text
                 normalized_entry = re.sub(r'^- ', '* ', entry_text, flags=re.MULTILINE)
-                if entry_text not in final_text and normalized_entry not in final_text:
+                normalized_final = re.sub(r'^- ', '* ', final_text, flags=re.MULTILINE)
+                if normalized_entry not in normalized_final:
                     patch_num = get_next_patch_num(final_text)
                     final_text += f'\n\n=== Patch {patch_num} ===\n\n{entry_text}'
                     logger.debug(f'Adding Patch {patch_num} to {date_key}')


### PR DESCRIPTION
When a wiki page existed, but no local file did, the bot would pull the wiki content as the base and then re-append the same forum content as a new section. This happened because the wiki uses `*` bullets while the forum scrape uses `-`, so the duplicate check didn't catch it.

Fixed by normalizing bullet styles before the duplicate check.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/206) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_