### PR TITLE
feat: add IsImbued flag to item parser and item cards

### DIFF
--- a/src/parser/parsers/item_cards.py
+++ b/src/parser/parsers/item_cards.py
@@ -36,6 +36,7 @@ class ItemCardParser:
             'IsDisabled',
             'StreetBrawl',
             'PropertyUpgrades',
+            'IsImbued',
         ]
 
         card = {
@@ -51,6 +52,7 @@ class ItemCardParser:
             'ShopFilters': item.get('ShopFilters'),
             'IsDisabled': item.get('IsDisabled'),
             'StreetBrawl': item.get('StreetBrawl'),
+            'IsImbued': item.get('IsImbued', False),
         }
 
         # Parse tooltip sections if available

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -63,6 +63,9 @@ class ItemParser:
         requirements = item_value.get('m_eAbilityRequirements', '')
         is_street_brawl = 'ERequirementStreetBrawl' in [r.strip() for r in requirements.split('|')]
 
+        target_effects = item_value.get('m_TargetAbilityEffectsToApply', '')
+        is_imbued = 'CITADEL_TARGET_ABILITY_BEHAVIOR_IMBUE_MODIFIER_VALUE' in target_effects
+
         parsed_item_data = {
             'Name': self.localizations.get(key),
             'Description': '',
@@ -75,6 +78,7 @@ class ItemParser:
             'ShopFilters': shop_filters,
             'IsDisabled': self._is_disabled(item_value),
             'StreetBrawl': is_street_brawl,
+            'IsImbued': is_imbued,
         }
 
         # Process attributes and extract scaling information


### PR DESCRIPTION
Adds an `IsImbued` boolean to identify items that can be imbued onto abilities, derived from `m_TargetAbilityEffectsToApply` in the raw item data.

- `items.py`: compute and include `IsImbued` in parsed item data
- `item_cards.py`: register `IsImbued` in `used_attributes` and the card dict

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/207) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_