### PR TITLE
fix: BonusAttackRange level scaling to display in meters

### DIFF
--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -2,6 +2,7 @@ import copy
 import parser.maps as maps
 import utils.json_utils as json_utils
 from utils.num_utils import round_sig_figs
+from constants import ENGINE_UNITS_PER_METER
 from . import weapon_parser
 
 
@@ -86,6 +87,12 @@ class HeroParser:
                     hero_stats['LevelScaling'] = {}
                     for key in level_scalings:
                         hero_stats['LevelScaling'][maps.get_level_mod(key)] = level_scalings[key]
+
+                    # Convert BonusAttackRange from engine units (inches) to meters
+                    if 'BonusAttackRange' in hero_stats['LevelScaling']:
+                        hero_stats['LevelScaling']['BonusAttackRange'] = round_sig_figs(
+                            hero_stats['LevelScaling']['BonusAttackRange'] / ENGINE_UNITS_PER_METER, 3
+                        )
 
                     # Spread the MeleeDamage level scaling into Light and Heavy, using H/L ratio
                     if 'MeleeDamage' in hero_stats['LevelScaling']:

--- a/src/parser/parsers/heroes.py
+++ b/src/parser/parsers/heroes.py
@@ -1,8 +1,8 @@
 import copy
 import parser.maps as maps
 import utils.json_utils as json_utils
+from utils import num_utils
 from utils.num_utils import round_sig_figs
-from constants import ENGINE_UNITS_PER_METER
 from . import weapon_parser
 
 
@@ -90,8 +90,8 @@ class HeroParser:
 
                     # Convert BonusAttackRange from engine units (inches) to meters
                     if 'BonusAttackRange' in hero_stats['LevelScaling']:
-                        hero_stats['LevelScaling']['BonusAttackRange'] = round_sig_figs(
-                            hero_stats['LevelScaling']['BonusAttackRange'] / ENGINE_UNITS_PER_METER, 3
+                        hero_stats['LevelScaling']['BonusAttackRange'] = num_utils.convert_engine_units_to_meters(
+                            hero_stats['LevelScaling']['BonusAttackRange'], sigfigs=3
                         )
 
                     # Spread the MeleeDamage level scaling into Light and Heavy, using H/L ratio


### PR DESCRIPTION
Converts `BonusAttackRange` from engine units to meters in hero level scaling data.

Fixes #349

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/208) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_