### PR TITLE
fix: handle ability upgrade property name typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Deadbot" 
-version = "1.11.0"
+version = "1.11.1"
 description = "Bot that lives to serve deadlock.wiki"
 readme = "README.md"
 authors=[]

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -44,6 +44,8 @@ def parse_upgrades(ability):
         raw_upgrades: list[RawUpgrade] = []
         for upgrade in upgrades:
             prop = upgrade.get('m_strPropertyName')
+            if prop is None:
+                prop = upgrade.get('m_StrPropertyNAme')  # known typo
             raw_value = upgrade.get('m_strBonus')
             upgrade_type = upgrade.get('m_eUpgradeType')
             scale_type = upgrade.get('m_eScaleStatFilter')


### PR DESCRIPTION
Fixes a typo in some ability upgrade data (`m_StrPropertyNAme` instead of `m_strPropertyName`). This was causing a `"null": -25` entry in the parsed JSON for `citadel_ability_infinity_slash` (Yamato's ult), which broke the ability card's second upgrade display on the wiki.

Now properly reads `"AbilityCooldown": -25`.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/213) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_