### PR TITLE
feat: extract modifier hierarchy from abilities

### DIFF
--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -3,6 +3,7 @@ from . import utils
 import utils.json_utils as json_utils
 import utils.num_utils as num_utils
 from .upgrades import parse_upgrades
+from .modifiers import parse_modifiers
 from loguru import logger
 
 
@@ -54,10 +55,8 @@ class AbilityParser:
             else:
                 ability_data[key] = value
 
-        if 'm_vecAbilityUpgrades' in ability:
-            ability_data['Upgrades'] = parse_upgrades(ability)
-        else:
-            ability_data['Upgrades'] = []
+        ability_data.update(parse_upgrades(ability))
+        ability_data.update(parse_modifiers(ability))
 
         formatted_ability_data = {}
         for attr_key, attr_value in ability_data.items():

--- a/src/parser/parsers/abilities/modifiers.py
+++ b/src/parser/parsers/abilities/modifiers.py
@@ -1,0 +1,91 @@
+import re
+
+
+_PREFIX_RE = re.compile(r'[A-Z]')
+_MODIFIER_VALUES_KEY = 'm_vecAutoRegisterModifierValueFromAbilityPropertyName'
+
+
+def parse_modifiers(ability: dict) -> dict:
+    """Walk an ability and extract a nested modifier hierarchy.
+
+    Any key whose name contains 'modifier' (case-insensitive).
+    The output uses the same keys as source but strips the prefixes
+    (e.g. m_DebuffModifier -> DebuffModifier,
+    m_AutoIntrinsicModifiers -> AutoIntrinsicModifiers).
+
+    From each modifier node, copy:
+      - _class -> Class (verbatim, only if a non-empty string)
+      - _my_subclass_name -> Subclass (verbatim, only if a non-empty string)
+      - m_vecAutoRegisterModifierValueFromAbilityPropertyName ->
+        AutoRegisterModifierValueFromAbilityPropertyName (verbatim list of
+        property names, only if non-empty).
+      - direct int/float children -> key stripped of its lowercase prefix
+        (e.g. m_flDuration -> Duration), value verbatim.
+      - nested modifier-named children, recursively (same recursion gate).
+
+    Nodes that end up with no fields at all (only empty class etc.) are omitted.
+    """
+    return _parse_dict_modifiers(ability)
+
+
+def _strip_prefix(key: str) -> str:
+    match = _PREFIX_RE.search(key)
+    if match:
+        return key[match.start() :]
+    return key
+
+
+def _parse_dict_modifiers(node: dict) -> dict:
+    out = {}
+    for k, v in node.items():
+        if 'modifier' not in k.lower():
+            continue
+        parsed = _parse_modifier_value(v)
+        if parsed is not None:
+            out[_strip_prefix(k)] = parsed
+    return out
+
+
+def _parse_modifier_value(value):
+    if isinstance(value, dict):
+        return _parse_modifier_node(value)
+    if isinstance(value, list):
+        items = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            parsed = _parse_modifier_node(item)
+            if parsed is not None:
+                items.append(parsed)
+        return items if items else None
+    return None
+
+
+def _parse_modifier_node(node: dict) -> dict | None:
+    out = {}
+
+    cls = node.get('_class')
+    if isinstance(cls, str) and cls:
+        out['Class'] = cls
+    subclass = node.get('_my_subclass_name')
+    if isinstance(subclass, str) and subclass:
+        out['Subclass'] = subclass
+
+    auto_register = node.get(_MODIFIER_VALUES_KEY)
+    if isinstance(auto_register, list) and auto_register:
+        out[_strip_prefix(_MODIFIER_VALUES_KEY)] = auto_register
+
+    for k, v in node.items():
+        if k in ('_class', '_my_subclass_name', _MODIFIER_VALUES_KEY):
+            continue
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            out[_strip_prefix(k)] = v
+            continue
+        if 'modifier' in k.lower():
+            parsed = _parse_modifier_value(v)
+            if parsed is not None:
+                out[_strip_prefix(k)] = parsed
+
+    return out or None

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -31,7 +31,9 @@ BASE_UPGRADE_TYPES = [None, 'EAddToBase', 'EMultiplyBase']
 SCALE_UPGRADE_TYPES = ['EAddToScale', 'EMultiplyScale']
 
 
-def parse_upgrades(ability):
+def parse_upgrades(ability: dict) -> dict:
+    if 'm_vecAbilityUpgrades' not in ability:
+        return {'Upgrades': []}
     upgrade_sets = ability['m_vecAbilityUpgrades']
     parsed_upgrade_sets = []
 
@@ -115,4 +117,4 @@ def parse_upgrades(ability):
 
         parsed_upgrade_sets.append(parsed_upgrade_set)
 
-    return parsed_upgrade_sets
+    return {'Upgrades': parsed_upgrade_sets}


### PR DESCRIPTION
Add parsing of all \*modifier\* fields in abilities. These fields are going to be exported and will include several hardcoded props + any int/float props. The hardcoded props like class/subclass will allow wiki maintainers to better use this in Lua automations to filter abilities that have some specific debuffs e.g. silence. The int/float props can be used to reference in abilities notes, like how melee buildup for Afterburn is a prop inside *modifier* field.

An example of how abilitydata.json would look like after this can be seen here
https://github.com/Vergir/deadlock-data/pull/1/changes