### PR TITLE
feat: extract item investment stats

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -36,6 +36,15 @@ SLOT_TYPE_MAP = {
     'EItemSlotType_Tech': 'Tech',
 }
 
+# Maps slot-type enums to stat-category names for item investment thresholds.
+# Differs from SLOT_TYPE_MAP above which maps to slot-display names (Armor/Tech).
+# Keeping both is intentional, the wiki modules consume category names.
+INVESTMENT_SLOT_MAP = {
+    'EItemSlotType_WeaponMod': 'Weapon',
+    'EItemSlotType_Armor': 'Vitality',
+    'EItemSlotType_Tech': 'Spirit',
+}
+
 
 def get_slot_type(value):
     if value is None:

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -150,6 +150,7 @@ class Parser:
         self._parse_localizations()
         self._parse_soul_unlocks()
         self._parse_generics()
+        self._parse_item_investments()
         self._parse_misc()
         self._parse_convars()
         self._parse_street_brawl()
@@ -165,13 +166,16 @@ class Parser:
     def _parse_generics(self):
         logger.trace('Parsing Generics...')
         generic_data_path = self.OUTPUT_DIR + '/json/generic-data.json'
+        parsed_generics = generics.GenericParser(generic_data_path, self.data['scripts']['generic_data']).run()
 
-        generic_data = dict(self.data['scripts']['generic_data'])
-        parsed_investments = item_investment.ItemInvestmentParser(self.data['scripts']['heroes']).run()
-        generic_data.update(parsed_investments)
-
-        parsed_generics = generics.GenericParser(generic_data_path, generic_data).run()
         json_utils.write(generic_data_path, json_utils.sort_dict(parsed_generics))
+
+    def _parse_item_investments(self):
+        logger.trace('Parsing Item Investments...')
+        parsed_investments = item_investment.ItemInvestmentParser(self.data['scripts']['heroes']).run()
+
+        investment_data_path = self.OUTPUT_DIR + '/json/item-investment-data.json'
+        json_utils.write(investment_data_path, json_utils.sort_dict(parsed_investments))
 
     def _parse_localizations(self):
         logger.trace('Parsing Localizations...')

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import json
 
 from .parsers import (
     abilities,
@@ -164,9 +165,56 @@ class Parser:
     def _parse_generics(self):
         logger.trace('Parsing Generics...')
         generic_data_path = self.OUTPUT_DIR + '/json/generic-data.json'
-        parsed_generics = generics.GenericParser(generic_data_path, self.data['scripts']['generic_data']).run()
 
+        generic_data = dict(self.data['scripts']['generic_data'])
+        generic_data.update(self._extract_item_investment_stats())
+
+        parsed_generics = generics.GenericParser(generic_data_path, generic_data).run()
         json_utils.write(generic_data_path, json_utils.sort_dict(parsed_generics))
+
+    INVESTMENT_SLOT_MAP = {
+        'EItemSlotType_WeaponMod': 'Weapon',
+        'EItemSlotType_Armor': 'Vitality',
+        'EItemSlotType_Tech': 'Spirit',
+    }
+
+    def _extract_item_investment_stats(self) -> dict:
+        first = None
+        first_key = None
+        for hero_key, hero_data in self.data['scripts']['heroes'].items():
+            if not isinstance(hero_data, dict):
+                continue
+            if hero_key == 'hero_base':
+                continue
+            if not hero_data.get('m_bPlayerSelectable', False):
+                continue
+            if 'm_MapModCostBonuses' not in hero_data:
+                # This should not happen for a selectable hero, but we'll skip
+                logger.warning(f'Selectable hero {hero_key} missing m_MapModCostBonuses')
+                continue
+
+            remapped = {
+                self.INVESTMENT_SLOT_MAP[slot]: entries
+                for slot, entries in hero_data['m_MapModCostBonuses'].items()
+                if slot in self.INVESTMENT_SLOT_MAP
+            }
+
+            if first is None:
+                first = remapped
+                first_key = hero_key
+            else:
+                # deep compare dictionaries (order shouldn't matter because we use same remapping)
+                if json.dumps(first, sort_keys=True) != json.dumps(remapped, sort_keys=True):
+                    raise ValueError(
+                        f'Item investment stats differ between heroes {first_key} and {hero_key}.\n' f'{first_key}: {first}\n{hero_key}: {remapped}'
+                    )
+
+        if first is None:
+            logger.warning('Could not find m_MapModCostBonuses in any selectable hero')
+            return {}
+
+        logger.trace(f'Extracted item investment stats from {first_key} (validated across all selectable heroes)')
+        return {'ItemInvestments': first}
 
     def _parse_localizations(self):
         logger.trace('Parsing Localizations...')

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import json
 
 from .parsers import (
     abilities,
@@ -18,6 +17,7 @@ from .parsers import (
     misc,
     convars,
     street_brawl,
+    item_investment,
 )
 from utils import json_utils
 from loguru import logger
@@ -167,54 +167,11 @@ class Parser:
         generic_data_path = self.OUTPUT_DIR + '/json/generic-data.json'
 
         generic_data = dict(self.data['scripts']['generic_data'])
-        generic_data.update(self._extract_item_investment_stats())
+        parsed_investments = item_investment.ItemInvestmentParser(self.data['scripts']['heroes']).run()
+        generic_data.update(parsed_investments)
 
         parsed_generics = generics.GenericParser(generic_data_path, generic_data).run()
         json_utils.write(generic_data_path, json_utils.sort_dict(parsed_generics))
-
-    INVESTMENT_SLOT_MAP = {
-        'EItemSlotType_WeaponMod': 'Weapon',
-        'EItemSlotType_Armor': 'Vitality',
-        'EItemSlotType_Tech': 'Spirit',
-    }
-
-    def _extract_item_investment_stats(self) -> dict:
-        first = None
-        first_key = None
-        for hero_key, hero_data in self.data['scripts']['heroes'].items():
-            if not isinstance(hero_data, dict):
-                continue
-            if hero_key == 'hero_base':
-                continue
-            if not hero_data.get('m_bPlayerSelectable', False):
-                continue
-            if 'm_MapModCostBonuses' not in hero_data:
-                # This should not happen for a selectable hero, but we'll skip
-                logger.warning(f'Selectable hero {hero_key} missing m_MapModCostBonuses')
-                continue
-
-            remapped = {
-                self.INVESTMENT_SLOT_MAP[slot]: entries
-                for slot, entries in hero_data['m_MapModCostBonuses'].items()
-                if slot in self.INVESTMENT_SLOT_MAP
-            }
-
-            if first is None:
-                first = remapped
-                first_key = hero_key
-            else:
-                # deep compare dictionaries (order shouldn't matter because we use same remapping)
-                if json.dumps(first, sort_keys=True) != json.dumps(remapped, sort_keys=True):
-                    raise ValueError(
-                        f'Item investment stats differ between heroes {first_key} and {hero_key}.\n' f'{first_key}: {first}\n{hero_key}: {remapped}'
-                    )
-
-        if first is None:
-            logger.warning('Could not find m_MapModCostBonuses in any selectable hero')
-            return {}
-
-        logger.trace(f'Extracted item investment stats from {first_key} (validated across all selectable heroes)')
-        return {'ItemInvestments': first}
 
     def _parse_localizations(self):
         logger.trace('Parsing Localizations...')

--- a/src/parser/parsers/generics.py
+++ b/src/parser/parsers/generics.py
@@ -14,7 +14,7 @@ class GenericParser:
     """
 
     def __init__(self, output_dir, generic_data):
-        self.STRUCTURE_KEYS_TO_VALIDATE = ['ObjectiveParams', 'RejuvParams', 'ItemPricePerTier']
+        self.STRUCTURE_KEYS_TO_VALIDATE = ['ObjectiveParams', 'RejuvParams', 'ItemPricePerTier', 'ItemInvestments']
         self.POSSIBLE_PREFIXES = ['m_str', 'm_map', 'm_n', 'm_fl', 'm_', 'fl', 'E', 'n']
         self.generic_data_dir = output_dir
         self.generic_data = generic_data

--- a/src/parser/parsers/generics.py
+++ b/src/parser/parsers/generics.py
@@ -14,7 +14,7 @@ class GenericParser:
     """
 
     def __init__(self, output_dir, generic_data):
-        self.STRUCTURE_KEYS_TO_VALIDATE = ['ObjectiveParams', 'RejuvParams', 'ItemPricePerTier', 'ItemInvestments']
+        self.STRUCTURE_KEYS_TO_VALIDATE = ['ObjectiveParams', 'RejuvParams', 'ItemPricePerTier']
         self.POSSIBLE_PREFIXES = ['m_str', 'm_map', 'm_n', 'm_fl', 'm_', 'fl', 'E', 'n']
         self.generic_data_dir = output_dir
         self.generic_data = generic_data

--- a/src/parser/parsers/item_investment.py
+++ b/src/parser/parsers/item_investment.py
@@ -1,0 +1,54 @@
+from loguru import logger
+
+from parser.maps import INVESTMENT_SLOT_MAP
+
+
+class ItemInvestmentParser:
+    """
+    Parses item investment (slot threshold) data from hero definitions.
+
+    Every selectable hero shares the same m_MapModCostBonuses map, which
+    defines the soul-cost brackets for items in each slot category (Weapon,
+    Vitality, Spirit).  The parser validates consistency across all heroes
+    and returns a single merged dict.
+    """
+
+    def __init__(self, heroes_data):
+        self.heroes_data = heroes_data
+
+    def run(self) -> dict:
+        first = None
+        first_key = None
+
+        for hero_key, hero_data in self.heroes_data.items():
+            if not isinstance(hero_data, dict):
+                continue
+            if hero_key == 'hero_base':
+                continue
+            if not hero_data.get('m_bPlayerSelectable', False):
+                continue
+            if 'm_MapModCostBonuses' not in hero_data:
+                logger.warning(f'Selectable hero {hero_key} missing m_MapModCostBonuses')
+                continue
+
+            remapped = {}
+            for slot, entries in hero_data['m_MapModCostBonuses'].items():
+                if slot in INVESTMENT_SLOT_MAP:
+                    remapped[INVESTMENT_SLOT_MAP[slot]] = entries
+                else:
+                    logger.warning(f'Unknown investment slot {slot} in hero {hero_key}')
+
+            if first is None:
+                first = remapped
+                first_key = hero_key
+            else:
+                if first != remapped:
+                    raise ValueError(
+                        f'Item investment stats differ between heroes {first_key} and {hero_key}.\n' f'{first_key}: {first}\n{hero_key}: {remapped}'
+                    )
+
+        if first is None:
+            raise ValueError('Could not find m_MapModCostBonuses in any selectable hero. ' 'Item investment data cannot be extracted.')
+
+        logger.trace(f'Extracted item investment stats from {first_key} ' '(validated across all selectable heroes)')
+        return {'ItemInvestments': first}

--- a/src/parser/parsers/item_investment.py
+++ b/src/parser/parsers/item_investment.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+import utils.string_utils as string_utils
 from parser.maps import INVESTMENT_SLOT_MAP
 
 
@@ -13,8 +14,27 @@ class ItemInvestmentParser:
     and returns a single merged dict.
     """
 
+    PREFIXES = ['m_str', 'm_map', 'm_n', 'm_fl', 'm_', 'fl', 'E', 'n']
+
     def __init__(self, heroes_data):
         self.heroes_data = heroes_data
+
+    def _clean_keys(self, data: dict) -> dict:
+        """Recursively remove prefixes from keys in a dictionary."""
+        cleaned = {}
+        for key, value in data.items():
+            new_key = key
+            for prefix in self.PREFIXES:
+                new_key = string_utils.remove_prefix(key, prefix)
+                if new_key != key:
+                    break
+
+            # If value is a dict, recursively clean its keys
+            if isinstance(value, dict):
+                value = self._clean_keys(value)
+
+            cleaned[new_key] = value
+        return cleaned
 
     def run(self) -> dict:
         first = None
@@ -34,7 +54,9 @@ class ItemInvestmentParser:
             remapped = {}
             for slot, entries in hero_data['m_MapModCostBonuses'].items():
                 if slot in INVESTMENT_SLOT_MAP:
-                    remapped[INVESTMENT_SLOT_MAP[slot]] = entries
+                    # Clean prefixes from keys (e.g. m_nGoldThreshold -> GoldThreshold)
+                    cleaned_entries = [self._clean_keys(entry) for entry in entries]
+                    remapped[INVESTMENT_SLOT_MAP[slot]] = cleaned_entries
                 else:
                     logger.warning(f'Unknown investment slot {slot} in hero {hero_key}')
 

--- a/src/wiki/pages.py
+++ b/src/wiki/pages.py
@@ -9,6 +9,7 @@ DATA_PAGE_FILE_MAP = {
     'HeroMeaningfulStats.json': 'json/hero-meaningful-stats.json',
     'ItemData.json': 'json/item-data.json',
     'ItemCards.json': 'json/item-cards.json',
+    'ItemInvestmentData.json': 'json/item-investment-data.json',
     'NpcData.json': 'json/npc-data.json',
     'Lang bg.json': 'localizations/bulgarian.json',
     'Lang cs.json': 'localizations/czech.json',


### PR DESCRIPTION
Valve currently stores the item investment thresholds (the stat bonuses you get at 800, 1600 souls, etc.) inside every individual hero's data. This PR pulls that data out and writes it to a dedicated `item-investment-data.json`.

**What it does:**
- Extracts `m_MapModCostBonuses` and maps the slots to `Weapon`, `Vitality`, and `Spirit`.
- Cross-checks all playable heroes against each other. If Valve gives one hero different scaling in a future patch, the parser stops.
- Outputs the clean data to a dedicated `item-investment-data.json` file.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/215) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_