### PR TITLE
Case insensitive key matching

### DIFF
--- a/src/decompiler/decompiler.py
+++ b/src/decompiler/decompiler.py
@@ -37,7 +37,7 @@ class Decompiler:
         self._import_localization_data()
 
         # Save version information to prevent unnecessary future decompiles
-        os.system(f'cp "{steam_inf_path}" "{version_path}"')
+        shutil.copy(steam_inf_path, version_path)
 
     def _import_game_data(self):
         """

--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -161,11 +161,6 @@ def get_bound_abilities(value):
 
 
 LOCALIZATION_OVERRIDE_MAP = {
-    # Semantic renames: the variable name in a localization string is
-    # different from (not just a case variant of) the data key. Case-only
-    # typos (e.g. AbilitYCharges, MinDPS) are handled by the
-    # CaseInsensitiveDict in string_utils.format_description and do not
-    # need entries here.
     'ArcaneSurgeWindow': 'AbilityDuration',
     'MaxChargeDuration': 'SpeedBoostDuration',
 }

--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -161,10 +161,13 @@ def get_bound_abilities(value):
 
 
 LOCALIZATION_OVERRIDE_MAP = {
-    'AbilitYCharges': 'AbilityCharges',
+    # Semantic renames: the variable name in a localization string is
+    # different from (not just a case variant of) the data key. Case-only
+    # typos (e.g. AbilitYCharges, MinDPS) are handled by the
+    # CaseInsensitiveDict in string_utils.format_description and do not
+    # need entries here.
     'ArcaneSurgeWindow': 'AbilityDuration',
     'MaxChargeDuration': 'SpeedBoostDuration',
-    'MinDPS': 'MinDps',
 }
 
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -79,12 +79,16 @@ class Parser:
         # Convert .vdata_c to .vdata and .json
         scripts_path = 'scripts'
 
-        # Load json files to memory
+        # Load json files to memory. Each script tree is wrapped in a
+        # CaseInsensitiveDict so downstream parsers tolerate Valve's
+        # occasional capitalization typos (e.g. m_strVAlue, AbilitYCharges)
+        # without per-parser fallback code.
         for file_name in os.listdir(os.path.join(self.DATA_DIR, scripts_path)):
             if file_name.endswith('.json'):
                 # path/to/scripts/abilities.json -> abilities
                 key = file_name.split('.')[0].split('/')[-1]
-                self.data['scripts'][key] = json_utils.read(os.path.join(self.DATA_DIR, scripts_path, file_name))
+                raw = json_utils.read(os.path.join(self.DATA_DIR, scripts_path, file_name))
+                self.data['scripts'][key] = json_utils.wrap_case_insensitive(raw)
 
     def _load_localizations(self):
         """

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -79,10 +79,7 @@ class Parser:
         # Convert .vdata_c to .vdata and .json
         scripts_path = 'scripts'
 
-        # Load json files to memory. Each script tree is wrapped in a
-        # CaseInsensitiveDict so downstream parsers tolerate Valve's
-        # occasional capitalization typos (e.g. m_strVAlue, AbilitYCharges)
-        # without per-parser fallback code.
+        # Load json files to memory
         for file_name in os.listdir(os.path.join(self.DATA_DIR, scripts_path)):
             if file_name.endswith('.json'):
                 # path/to/scripts/abilities.json -> abilities

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -136,7 +136,6 @@ class Parser:
 
     def run(self):
         logger.trace('Parsing...')
-        os.system(f'cp "{self.DATA_DIR}/version.txt" "{self.OUTPUT_DIR}/version.txt"')
         parsed_abilities = self._parse_abilities()
         parsed_heroes = self._parse_heroes(parsed_abilities)
         self._parsed_ability_cards(parsed_heroes)

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -8,7 +8,10 @@ from loguru import logger
 
 class AbilityParser:
     def __init__(self, abilities_data, heroes_data, localizations):
-        self.abilities_data = abilities_data
+        # Wrap with a case-insensitive dict so inconsistent capitalization in
+        # Valve's source data (e.g. AbilitYCharges, m_strVAlue) doesn't make
+        # lookups silently miss. Original key casing is preserved for output.
+        self.abilities_data = json_utils.wrap_case_insensitive(abilities_data)
         self.heroes_data = heroes_data
         self.localizations = localizations
 
@@ -29,7 +32,7 @@ class AbilityParser:
     def _parse_ability(self, ability_key):
         ability = self.abilities_data[ability_key]
 
-        if type(ability) is not dict:
+        if not isinstance(ability, dict):
             return
 
         if 'm_eAbilityType' not in ability:
@@ -66,14 +69,10 @@ class AbilityParser:
         return json_utils.sort_dict(formatted_ability_data)
 
     def _get_stat_value(self, key, stat):
-        value = None
-
-        if 'm_strValue' in stat:
-            value = stat['m_strValue']
-        elif 'm_strVAlue' in stat:
-            value = stat['m_strVAlue']
-        else:
+        # Case-insensitive lookup handles the 'm_strVAlue' typo variant.
+        if 'm_strValue' not in stat:
             return
+        value = stat['m_strValue']
 
         return utils.convert_stat(stat, key, value)
 

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -8,10 +8,6 @@ from loguru import logger
 
 class AbilityParser:
     def __init__(self, abilities_data, heroes_data, localizations):
-        # abilities_data and heroes_data arrive already wrapped in
-        # CaseInsensitiveDict by Parser._load_vdata, so inconsistent
-        # capitalization in Valve's source (e.g. m_strVAlue, AbilitYCharges)
-        # resolves transparently. Original key casing is preserved in output.
         self.abilities_data = abilities_data
         self.heroes_data = heroes_data
         self.localizations = localizations
@@ -70,7 +66,6 @@ class AbilityParser:
         return json_utils.sort_dict(formatted_ability_data)
 
     def _get_stat_value(self, key, stat):
-        # Case-insensitive lookup handles the 'm_strVAlue' typo variant.
         if 'm_strValue' not in stat:
             return
         value = stat['m_strValue']

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -8,10 +8,11 @@ from loguru import logger
 
 class AbilityParser:
     def __init__(self, abilities_data, heroes_data, localizations):
-        # Wrap with a case-insensitive dict so inconsistent capitalization in
-        # Valve's source data (e.g. AbilitYCharges, m_strVAlue) doesn't make
-        # lookups silently miss. Original key casing is preserved for output.
-        self.abilities_data = json_utils.wrap_case_insensitive(abilities_data)
+        # abilities_data and heroes_data arrive already wrapped in
+        # CaseInsensitiveDict by Parser._load_vdata, so inconsistent
+        # capitalization in Valve's source (e.g. m_strVAlue, AbilitYCharges)
+        # resolves transparently. Original key casing is preserved in output.
+        self.abilities_data = abilities_data
         self.heroes_data = heroes_data
         self.localizations = localizations
 

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -43,9 +43,8 @@ def parse_upgrades(ability):
         # 1. Extract raw data from each upgrade entry
         raw_upgrades: list[RawUpgrade] = []
         for upgrade in upgrades:
+            # Case-insensitive lookup handles the 'm_StrPropertyNAme' typo variant.
             prop = upgrade.get('m_strPropertyName')
-            if prop is None:
-                prop = upgrade.get('m_StrPropertyNAme')  # known typo
             raw_value = upgrade.get('m_strBonus')
             upgrade_type = upgrade.get('m_eUpgradeType')
             scale_type = upgrade.get('m_eScaleStatFilter')

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -43,7 +43,6 @@ def parse_upgrades(ability):
         # 1. Extract raw data from each upgrade entry
         raw_upgrades: list[RawUpgrade] = []
         for upgrade in upgrades:
-            # Case-insensitive lookup handles the 'm_StrPropertyNAme' typo variant.
             prop = upgrade.get('m_strPropertyName')
             raw_value = upgrade.get('m_strBonus')
             upgrade_type = upgrade.get('m_eUpgradeType')

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -20,7 +20,7 @@ class ItemParser:
         all_items = {}
         for key in self.abilities_data:
             ability = self.abilities_data[key]
-            if type(ability) is not dict:
+            if not isinstance(ability, dict):
                 continue
 
             # Skip the base class for cosmetics

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -162,7 +162,7 @@ def remove_keys(data, keys_to_remove, depths_to_search=1):
     """Remove keys from the first depths_to_search levels of a dictionary"""
     if depths_to_search == 0:
         return data
-    if type(data) is dict:
+    if isinstance(data, dict):
         data = data.copy()  # Don't alter the original data's memory
         for key in keys_to_remove:
             if key in data:

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -4,6 +4,124 @@ import os
 from utils import num_utils
 
 
+class CaseInsensitiveDict(dict):
+    """A dict that looks up string keys case-insensitively while preserving
+    the original key casing for iteration, JSON serialization, etc.
+
+    Designed to absorb inconsistent capitalization that occasionally appears
+    in Valve's data files (e.g. ``m_strVAlue`` vs ``m_strValue``,
+    ``AbilitYCharges`` vs ``AbilityCharges``).
+
+    Semantics:
+      - ``d[key]``, ``d.get(key)``, ``key in d`` all compare keys via
+        ``key.lower()``. The first stored casing of a key wins; subsequent
+        writes with a different casing replace the value but keep the
+        original key string. Non-string keys are stored exactly as-is.
+      - The dict still serializes / iterates with the original keys, so
+        downstream consumers see PascalCase or whatever casing the source
+        used.
+
+    Use ``wrap_case_insensitive`` to recursively convert a parsed JSON tree.
+    """
+
+    def __init__(self, data=None, **kwargs):
+        super().__init__()
+        # lowercased str key -> the canonical str key currently stored
+        self._ci_index: dict[str, str] = {}
+        if data is not None:
+            self.update(data)
+        if kwargs:
+            self.update(kwargs)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, str):
+            lower = key.lower()
+            existing = self._ci_index.get(lower)
+            if existing is not None and existing != key:
+                # collision: drop the prior case-variant so only one stays
+                dict.__delitem__(self, existing)
+            self._ci_index[lower] = key
+        dict.__setitem__(self, key, value)
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            actual = self._ci_index.get(key.lower())
+            if actual is None:
+                raise KeyError(key)
+            return dict.__getitem__(self, actual)
+        return dict.__getitem__(self, key)
+
+    def __delitem__(self, key):
+        if isinstance(key, str):
+            actual = self._ci_index.pop(key.lower(), None)
+            if actual is None:
+                raise KeyError(key)
+            dict.__delitem__(self, actual)
+            return
+        dict.__delitem__(self, key)
+
+    def __contains__(self, key):
+        if isinstance(key, str):
+            return key.lower() in self._ci_index
+        return dict.__contains__(self, key)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def pop(self, key, *args):
+        try:
+            value = self[key]
+        except KeyError:
+            if args:
+                return args[0]
+            raise
+        del self[key]
+        return value
+
+    def setdefault(self, key, default=None):
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+
+    def update(self, other=None, **kwargs):
+        if other is not None:
+            if hasattr(other, 'items'):
+                for k, v in other.items():
+                    self[k] = v
+            else:
+                for k, v in other:
+                    self[k] = v
+        for k, v in kwargs.items():
+            self[k] = v
+
+    def copy(self):
+        new = CaseInsensitiveDict()
+        for k, v in self.items():
+            new[k] = v
+        return new
+
+
+def wrap_case_insensitive(obj):
+    """Recursively wrap dict-trees in CaseInsensitiveDict.
+
+    Lists are traversed and their dict elements are wrapped; non-dict /
+    non-list values pass through unchanged. The input tree is not mutated;
+    a new wrapped tree is returned.
+    """
+    if isinstance(obj, dict):
+        wrapped = CaseInsensitiveDict()
+        for k, v in obj.items():
+            wrapped[k] = wrap_case_insensitive(v)
+        return wrapped
+    if isinstance(obj, list):
+        return [wrap_case_insensitive(item) for item in obj]
+    return obj
+
+
 def read(path, ignore_error=False):
     """
     Read data from a JSON file to memory.

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -106,12 +106,7 @@ class CaseInsensitiveDict(dict):
 
 
 def wrap_case_insensitive(obj):
-    """Recursively wrap dict-trees in CaseInsensitiveDict.
-
-    Lists are traversed and their dict elements are wrapped; non-dict /
-    non-list values pass through unchanged. The input tree is not mutated;
-    a new wrapped tree is returned.
-    """
+    """Recursively wrap dict-trees in CaseInsensitiveDict."""
     if isinstance(obj, dict):
         wrapped = CaseInsensitiveDict()
         for k, v in obj.items():

--- a/src/utils/parameters.py
+++ b/src/utils/parameters.py
@@ -6,9 +6,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-# Local helper kept here (not in utils.string_utils) so this module has no
-# dependency on string_utils. That avoids a circular import chain:
-#   parameters -> string_utils -> num_utils -> constants -> parameters
 def is_truthy(value):
     return value in (True, 'true', 'True', 'TRUE', 't', 'T', 1)
 

--- a/src/utils/parameters.py
+++ b/src/utils/parameters.py
@@ -3,9 +3,15 @@ import argparse
 from typing import Optional, Protocol
 from dotenv import load_dotenv
 
-from utils.string_utils import is_truthy
-
 load_dotenv()
+
+
+# Local helper kept here (not in utils.string_utils) so this module has no
+# dependency on string_utils. That avoids a circular import chain:
+#   parameters -> string_utils -> num_utils -> constants -> parameters
+def is_truthy(value):
+    return value in (True, 'true', 'True', 'TRUE', 't', 'T', 1)
+
 
 ARG_PARSER = argparse.ArgumentParser(
     prog='Deadbot',

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -4,7 +4,7 @@ import re
 
 from loguru import logger
 
-from utils import num_utils
+from utils import json_utils, num_utils
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import parser.maps as maps
@@ -24,12 +24,8 @@ def format_description(description, *data_sets):
         "<span class=\"highlight\">+{s:AbilityCastRange}m</span> Cast Range and gain <span class=\"highlight\">+{s:WeaponDamageBonus}</span> Weapon Damage for {s:WeaponDamageBonusDuration}s"
     ->  "+7 Weapon Damage for 10s after teleporting with Flying Cloak"
     """  # noqa: E501
-    # Local import to avoid a circular dependency
-    # (utils.json_utils <-> utils.num_utils <-> constants <-> utils.parameters <-> utils.string_utils).
     # Case-insensitive so typo'd variable names inside localization strings
     # (e.g. {s:AbilitYCharges}) still resolve to the canonical data key.
-    from utils import json_utils
-
     data = json_utils.CaseInsensitiveDict()
     for data_set in data_sets:
         data.update(data_set)
@@ -91,19 +87,6 @@ def _replace_variables(desc, data):
 def remove_letters(input_string):
     """Remove letters from a string. Eg. -4.5m -> -4.5"""
     return re.sub(r'[^0-9.\-]', '', input_string)
-
-
-def is_truthy(string):
-    TRUE_THO = [
-        True,
-        'true',
-        'True',
-        'TRUE',
-        't',
-        'T',
-        1,
-    ]
-    return string in TRUE_THO
 
 
 def remove_prefix(str, prefix):

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -24,8 +24,6 @@ def format_description(description, *data_sets):
         "<span class=\"highlight\">+{s:AbilityCastRange}m</span> Cast Range and gain <span class=\"highlight\">+{s:WeaponDamageBonus}</span> Weapon Damage for {s:WeaponDamageBonusDuration}s"
     ->  "+7 Weapon Damage for 10s after teleporting with Flying Cloak"
     """  # noqa: E501
-    # Case-insensitive so typo'd variable names inside localization strings
-    # (e.g. {s:AbilitYCharges}) still resolve to the canonical data key.
     data = json_utils.CaseInsensitiveDict()
     for data_set in data_sets:
         data.update(data_set)

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -24,7 +24,13 @@ def format_description(description, *data_sets):
         "<span class=\"highlight\">+{s:AbilityCastRange}m</span> Cast Range and gain <span class=\"highlight\">+{s:WeaponDamageBonus}</span> Weapon Damage for {s:WeaponDamageBonusDuration}s"
     ->  "+7 Weapon Damage for 10s after teleporting with Flying Cloak"
     """  # noqa: E501
-    data = {}
+    # Local import to avoid a circular dependency
+    # (utils.json_utils <-> utils.num_utils <-> constants <-> utils.parameters <-> utils.string_utils).
+    # Case-insensitive so typo'd variable names inside localization strings
+    # (e.g. {s:AbilitYCharges}) still resolve to the canonical data key.
+    from utils import json_utils
+
+    data = json_utils.CaseInsensitiveDict()
     for data_set in data_sets:
         data.update(data_set)
 


### PR DESCRIPTION
Added a new `CaseInsensitiveDict` class to json_utils. It's a wrapper for dicts that allows matching keys and handles typos automatically. Used this new class wherever we load data for parsing. The goal is to protect against typos breaking deadbot in future patches.

Also removed all previous case-hacks since they're not needed now.

(As a small aside I've also changed call to copy version file so it's actually cross-platform and works on Windows now.)