### PR TITLE
fix: defaulting to spirit scaling when scale type is missing

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -201,6 +201,52 @@ SCALE_TYPE_MAP = {
 }
 
 
+def _class_to_scale_type(class_str: str) -> str | None:
+    """
+    Infer the human-readable scale type from a _class string.
+    Returns a value like 'spirit', 'range', 'duration', 'cooldown', etc.
+    """
+    if not class_str:
+        return None
+
+    # Pattern 1: scale_function_<suffix>
+    if class_str.startswith('scale_function_'):
+        suffix = class_str[len('scale_function_') :]
+        # Map suffix to SCALE_TYPE_MAP key, then to human type
+        suffix_to_enum = {
+            'tech_damage': 'ETechPower',
+            'tech_range': 'ETechRange',
+            'tech_duration': 'ETechDuration',
+            'tech_cooldown': 'ETechCooldown',
+            'weapon_damage': 'EWeaponDamageScale',
+            'ability_charges': 'EMaxChargesIncrease',
+            'ability_recharge_time': 'ETechCooldown',  # cooldown between charges
+        }
+        enum_key = suffix_to_enum.get(suffix)
+        if enum_key:
+            return SCALE_TYPE_MAP.get(enum_key)
+
+    # Pattern 2: C<Name>ScaleFunction (e.g., CTechPowerScaleFunction)
+    elif class_str.startswith('C') and class_str.endswith('ScaleFunction'):
+        middle = class_str[1 : -len('ScaleFunction')]  # e.g., 'TechPower'
+        enum_key = 'E' + middle
+        return SCALE_TYPE_MAP.get(enum_key)
+
+    return None
+
+
+def _class_to_scale_enum(class_str: str) -> str | None:
+    """Return the enum key (e.g., 'ETechRange') from a _class string."""
+    human_type = _class_to_scale_type(class_str)
+    if not human_type:
+        return None
+    # Reverse lookup in SCALE_TYPE_MAP
+    for enum_key, human in SCALE_TYPE_MAP.items():
+        if human == human_type:
+            return enum_key
+    return None
+
+
 def get_scale_type(scale):
     if scale is None:
         return scale

--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -201,7 +201,7 @@ SCALE_TYPE_MAP = {
 }
 
 
-def _class_to_scale_type(class_str: str) -> str | None:
+def class_to_scale_type(class_str: str) -> str | None:
     """
     Infer the human-readable scale type from a _class string.
     Returns a value like 'spirit', 'range', 'duration', 'cooldown', etc.
@@ -235,9 +235,9 @@ def _class_to_scale_type(class_str: str) -> str | None:
     return None
 
 
-def _class_to_scale_enum(class_str: str) -> str | None:
+def class_to_scale_enum(class_str: str) -> str | None:
     """Return the enum key (e.g., 'ETechRange') from a _class string."""
-    human_type = _class_to_scale_type(class_str)
+    human_type = class_to_scale_type(class_str)
     if not human_type:
         return None
     # Reverse lookup in SCALE_TYPE_MAP

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -82,14 +82,26 @@ class AbilityParser:
         Get scale data for the ability attribute, which will refer to how the value of the attribute
         scales with another stat, usually Spirit
         """
-        if 'm_subclassScaleFunction' in stat:
-            scale = stat['m_subclassScaleFunction']
-            # Only include scale with a value, as not sure what
-            # any others mean so far.
-            if 'm_flStatScale' in scale:
-                return {
-                    'Value': scale['m_flStatScale'],
-                    'Type': maps.get_scale_type(scale.get('m_eSpecificStatScaleType', 'ETechPower')),
-                }
+        if 'm_subclassScaleFunction' not in stat:
+            return
+        scale = stat['m_subclassScaleFunction']
+        if 'm_flStatScale' not in scale:
+            return
 
-        return
+        scale_type = scale.get('m_eSpecificStatScaleType')
+        human_type = None
+        if scale_type:
+            human_type = maps.get_scale_type(scale_type)
+        else:
+            # Fallback: infer from _class
+            class_str = scale.get('_class', '')
+            if class_str:
+                human_type = maps._class_to_scale_type(class_str)
+            if not human_type:
+                # Last resort: default to spirit
+                human_type = maps.get_scale_type('ETechPower')
+
+        return {
+            'Value': scale['m_flStatScale'],
+            'Type': human_type,
+        }

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -96,7 +96,7 @@ class AbilityParser:
             # Fallback: infer from _class
             class_str = scale.get('_class', '')
             if class_str:
-                human_type = maps._class_to_scale_type(class_str)
+                human_type = maps.class_to_scale_type(class_str)
             if not human_type:
                 # Last resort: default to spirit
                 human_type = maps.get_scale_type('ETechPower')

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -92,7 +92,7 @@ def parse_upgrades(ability):
                             if scale_type is None:
                                 class_str = scale_func.get('_class', '')
                                 if class_str:
-                                    scale_type = maps._class_to_scale_enum(class_str)
+                                    scale_type = maps.class_to_scale_enum(class_str)
                     scale = {
                         'Value': entry['value'],
                         'Type': maps.get_scale_type(scale_type),

--- a/src/parser/parsers/abilities/upgrades.py
+++ b/src/parser/parsers/abilities/upgrades.py
@@ -89,8 +89,10 @@ def parse_upgrades(ability):
                         if base_stat and 'm_subclassScaleFunction' in base_stat:
                             scale_func = base_stat['m_subclassScaleFunction']
                             scale_type = scale_func.get('m_eSpecificStatScaleType')
-                            if scale_type is None and 'tech' in scale_func.get('_class', ''):
-                                scale_type = 'ETechPower'
+                            if scale_type is None:
+                                class_str = scale_func.get('_class', '')
+                                if class_str:
+                                    scale_type = maps._class_to_scale_enum(class_str)
                     scale = {
                         'Value': entry['value'],
                         'Type': maps.get_scale_type(scale_type),

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -172,9 +172,15 @@ class ItemParser:
             return None
 
         scale_type = scale_func.get('m_eSpecificStatScaleType')
-        human_type = get_scale_type(scale_type)
+        human_type = get_scale_type(scale_type) if scale_type else None
+
+        # Fallback to inferring from _class
         if not human_type:
-            return None
+            class_str = scale_func.get('_class', '')
+            if class_str:
+                human_type = maps._class_to_scale_type(class_str)
+            if not human_type:
+                return None
 
         try:
             base_value = num_utils.assert_number(base_value_str)

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -178,7 +178,7 @@ class ItemParser:
         if not human_type:
             class_str = scale_func.get('_class', '')
             if class_str:
-                human_type = maps._class_to_scale_type(class_str)
+                human_type = maps.class_to_scale_type(class_str)
             if not human_type:
                 return None
 

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -185,7 +185,7 @@ class ItemParser:
         try:
             base_value = num_utils.assert_number(base_value_str)
             scale_value = num_utils.assert_number(raw_scale_value)
-            if math.isnan(scale_value) or math.isinf(scale_value):
+            if math.isnan(scale_value) or math.isinf(scale_value) or scale_value == 0:
                 return None
         except (ValueError, TypeError):
             return None


### PR DESCRIPTION
When m_eSpecificStatScaleType is missing, we were defaulting to spirit scaling. Now we infer the correct type from the _class attribute instead (e.g. scale_function_tech_duration → duration scaling).

Also filtered out 0.0 scale values on items to reduce output noise.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/216) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_