### PR TITLE
feat: parse misc.vdata and export as misc-data.json

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -14,6 +14,7 @@ from .parsers import (
     generics,
     npc_units,
     game_map,
+    misc,
 )
 from utils import json_utils
 from loguru import logger
@@ -148,6 +149,7 @@ class Parser:
         self._parse_localizations()
         self._parse_soul_unlocks()
         self._parse_generics()
+        self._parse_misc()
         self._parse_map()
         logger.trace('Done parsing')
 
@@ -309,3 +311,9 @@ class Parser:
         ).run()
 
         json_utils.write(self.OUTPUT_DIR + '/json/resource-lookup.json', lookup)
+
+    def _parse_misc(self):
+        logger.trace('Parsing Misc...')
+        parsed_misc = misc.MiscParser(self.data['scripts']['misc']).run()
+
+        json_utils.write(self.OUTPUT_DIR + '/json/misc-data.json', json_utils.sort_dict(parsed_misc))

--- a/src/parser/parsers/misc.py
+++ b/src/parser/parsers/misc.py
@@ -1,0 +1,101 @@
+import utils.string_utils as string_utils
+
+
+class MiscParser:
+    """
+    Parses misc.vdata by stripping prefixes and filtering out internal data,
+    then uploads the whole thing.
+    Same approach as GenericParser.
+    """
+
+    # Prefixes to strip from keys, sorted longest-first to prevent
+    # partial matches (e.g. "m_nav" before "m_n")
+    PREFIXES = sorted(
+        [
+            'm_fl',
+            'm_b',
+            'm_n',
+            'm_i',
+            'm_str',
+            'm_vec',
+            'm_map',
+            'm_e',
+            'm_subclass',
+            'm_s',
+            'm_',
+        ],
+        key=len,
+        reverse=True,
+    )
+
+    # Internal metadata keys to remove
+    METADATA_KEYS = {
+        '_class',
+        '_my_subclass_name',
+        '_base',
+        '_not_pickable',
+        'generic_data_type',
+    }
+
+    def __init__(self, misc_data):
+        self.misc_data = misc_data
+
+    def run(self):
+        parsed = self._remove_prefixes(self.misc_data, self.PREFIXES)
+        return parsed
+
+    def _remove_prefixes(self, data, prefixes):
+        """Recursively strip prefixes from keys and filter out internal data."""
+        if isinstance(data, dict):
+            result = {}
+
+            for key, value in data.items():
+                # Skip internal metadata keys
+                if key in self.METADATA_KEYS:
+                    continue
+
+                # Skip base class definitions
+                if key.endswith('_base'):
+                    continue
+
+                # Strip prefix from key
+                clean_key = key
+                for prefix in prefixes:
+                    clean_key = string_utils.remove_prefix(key, prefix)
+                    if clean_key != key:
+                        break
+
+                # Force-strip m_ prefix when followed by lowercase
+                # e.g. m_modifierProvidedByAura -> modifierProvidedByAura
+                if clean_key.startswith('m_') and len(clean_key) > 2:
+                    clean_key = clean_key[2:]
+
+                # Recurse into nested structures
+                if isinstance(value, dict):
+                    value = self._remove_prefixes(value, prefixes)
+                elif isinstance(value, list):
+                    value = self._remove_prefixes_from_list(value, prefixes)
+
+                # Skip empty containers after filtering
+                if isinstance(value, (dict, list)) and len(value) == 0:
+                    continue
+
+                result[clean_key] = value
+
+            return result if result else {}
+
+        elif isinstance(data, list):
+            return self._remove_prefixes_from_list(data, prefixes)
+
+        return data
+
+    def _remove_prefixes_from_list(self, data, prefixes):
+        result = []
+        for item in data:
+            if isinstance(item, dict):
+                parsed = self._remove_prefixes(item, prefixes)
+                if parsed:
+                    result.append(parsed)
+            else:
+                result.append(item)
+        return result if result else []

--- a/src/wiki/pages.py
+++ b/src/wiki/pages.py
@@ -43,6 +43,7 @@ DATA_PAGE_FILE_MAP = {
     'StatInfoboxOrder.json': 'json/stat-infobox-order.json',
     'ResourceLookup.json': 'json/resource-lookup.json',
     'MidtownMetadata.json': 'json/midtown-metadata.json',
+    'MiscData.json': 'json/misc-data.json',
 }
 
 # Ignore these pages as they are not automated


### PR DESCRIPTION
Adds `MiscParser` to process `misc.vdata` (powerups, spawners, breakables, etc.) using the same prefix-stripping approach as `GenericParser`.

- Outputs to `json/misc-data.json`
- Strips `m_` prefixes (including lowercase edge cases)
- Filters out `_base` classes and metadata
- Adds mapping to wiki pages for upload

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/217) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_