### PR TITLE
fix: missing scaling data for healing items

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -221,6 +221,8 @@ def class_to_scale_type(class_str: str) -> str | None:
             'weapon_damage': 'EWeaponDamageScale',
             'ability_charges': 'EMaxChargesIncrease',
             'ability_recharge_time': 'ETechCooldown',  # cooldown between charges
+            'healing_spirit_scale': 'ETechPower',
+            'healing_boon_scale': 'ELevelUpBoons',
         }
         enum_key = suffix_to_enum.get(suffix)
         if enum_key:

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -180,7 +180,7 @@ class ItemParser:
             if class_str:
                 human_type = maps.class_to_scale_type(class_str)
             if not human_type:
-                return None
+                human_type = maps.get_scale_type('ETechPower')
 
         try:
             base_value = num_utils.assert_number(base_value_str)


### PR DESCRIPTION
Valve added new `_class`-based scale functions (`scale_function_healing_spirit_scale` and `scale_function_healing_boon_scale`) in a recent update. The item parser didn't recognize them, so scaling data was silently dropped for Radiant Regeneration, Healing Rite, Headhunter, Healing Nova, Restorative Locket, Lifestrike, and Veil Walker.

- Added the two new `_class` → enum mappings in `maps.py`
- Added spirit fallback in `items.py` `_extract_scaling()` to match the existing ability parser behavior instead of silently returning None

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/223) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_