### PR TITLE
feat: add AOE health pickup data for medic trooper

### DIFF
--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -325,28 +325,26 @@ class NpcParser:
         if npc_key == 'trooper_medic':
             pickup_data = self.misc_data.get('medic_trooper_aoe_health_pickup_amber')
             if pickup_data:
-                pickup_radius = pickup_data.get('m_flPickupRadius', {})
-                expiration_duration = pickup_data.get('m_flPickupExpirationDuration', {})
-                regen_fixed = pickup_data.get('m_flRegenFixed', {})
-                heal_fixed = pickup_data.get('m_flHealFixed', {})
                 parsed_data['AOEHealthPickup'] = {
-                    'AOERadius': convert_engine_units_to_meters(pickup_data.get('m_flAOERadius')),
-                    'PickupRadiusBase': convert_engine_units_to_meters(pickup_radius.get('m_flBase')),
-                    'PickupRadiusScaling': convert_engine_units_to_meters(pickup_radius.get('m_flPerMinuteAfterStart')),
-                    'PickupRadiusMax': convert_engine_units_to_meters(pickup_radius.get('m_flMaxValue')),
-                    'PickupRadiusStartMinute': pickup_radius.get('m_flStartMinute'),
-                    'MissingPctRegen': pickup_data.get('m_flMissingPctRegen', {}).get('m_flBase'),
-                    'RegenFixed': regen_fixed.get('m_flBase'),
-                    'RegenFixedScaling': regen_fixed.get('m_flPerMinuteAfterStart'),
-                    'RegenDuration': pickup_data.get('m_flRegenDuration'),
-                    'RegenDurationTroopers': pickup_data.get('m_flRegenDurationTroopers'),
-                    'RegenTrooperMultiplier': pickup_data.get('m_flRegenTrooperMulti'),
-                    'RegenHPS': pickup_data.get('m_flRegenHPS'),
-                    'HealFixed': heal_fixed.get('m_flBase'),
-                    'HealFixedScaling': heal_fixed.get('m_flPerMinuteAfterStart'),
-                    'PickupExpirationDurationBase': expiration_duration.get('m_flBase'),
-                    'PickupExpirationDurationScaling': expiration_duration.get('m_flPerMinuteAfterStart'),
-                    'PickupExpirationDurationMax': expiration_duration.get('m_flMaxValue'),
-                    'PickupExpirationStartMinute': expiration_duration.get('m_flStartMinute'),
-                    'SameTeamOnly': pickup_data.get('m_bSameTeamOnly'),
+                    'AOERadius': convert_engine_units_to_meters(json_utils.deep_get(pickup_data, 'm_flAOERadius')),
+                    'PickupRadiusBase': convert_engine_units_to_meters(json_utils.deep_get(pickup_data, 'm_flPickupRadius', 'm_flBase')),
+                    'PickupRadiusScaling': convert_engine_units_to_meters(
+                        json_utils.deep_get(pickup_data, 'm_flPickupRadius', 'm_flPerMinuteAfterStart')
+                    ),
+                    'PickupRadiusMax': convert_engine_units_to_meters(json_utils.deep_get(pickup_data, 'm_flPickupRadius', 'm_flMaxValue')),
+                    'PickupRadiusStartMinute': json_utils.deep_get(pickup_data, 'm_flPickupRadius', 'm_flStartMinute'),
+                    'MissingPctRegen': json_utils.deep_get(pickup_data, 'm_flMissingPctRegen', 'm_flBase'),
+                    'RegenFixed': json_utils.deep_get(pickup_data, 'm_flRegenFixed', 'm_flBase'),
+                    'RegenFixedScaling': json_utils.deep_get(pickup_data, 'm_flRegenFixed', 'm_flPerMinuteAfterStart'),
+                    'RegenDuration': json_utils.deep_get(pickup_data, 'm_flRegenDuration'),
+                    'RegenDurationTroopers': json_utils.deep_get(pickup_data, 'm_flRegenDurationTroopers'),
+                    'RegenTrooperMultiplier': json_utils.deep_get(pickup_data, 'm_flRegenTrooperMulti'),
+                    'RegenHPS': json_utils.deep_get(pickup_data, 'm_flRegenHPS'),
+                    'HealFixed': json_utils.deep_get(pickup_data, 'm_flHealFixed', 'm_flBase'),
+                    'HealFixedScaling': json_utils.deep_get(pickup_data, 'm_flHealFixed', 'm_flPerMinuteAfterStart'),
+                    'PickupExpirationDurationBase': json_utils.deep_get(pickup_data, 'm_flPickupExpirationDuration', 'm_flBase'),
+                    'PickupExpirationDurationScaling': json_utils.deep_get(pickup_data, 'm_flPickupExpirationDuration', 'm_flPerMinuteAfterStart'),
+                    'PickupExpirationDurationMax': json_utils.deep_get(pickup_data, 'm_flPickupExpirationDuration', 'm_flMaxValue'),
+                    'PickupExpirationStartMinute': json_utils.deep_get(pickup_data, 'm_flPickupExpirationDuration', 'm_flStartMinute'),
+                    'SameTeamOnly': json_utils.deep_get(pickup_data, 'm_bSameTeamOnly'),
                 }

--- a/src/parser/parsers/npc_units.py
+++ b/src/parser/parsers/npc_units.py
@@ -320,3 +320,33 @@ class NpcParser:
             resist_modifier = self.modifiers_data.get('modifier_citadel_trooper_in_enemy_base_resist')
             if resist_modifier:
                 parsed_data['EnemyBaseDamageReduction'] = resist_modifier.get('m_flDamageReductionForTroopers')
+
+        # Trooper Medic AOE Health Pickup (from misc_data)
+        if npc_key == 'trooper_medic':
+            pickup_data = self.misc_data.get('medic_trooper_aoe_health_pickup_amber')
+            if pickup_data:
+                pickup_radius = pickup_data.get('m_flPickupRadius', {})
+                expiration_duration = pickup_data.get('m_flPickupExpirationDuration', {})
+                regen_fixed = pickup_data.get('m_flRegenFixed', {})
+                heal_fixed = pickup_data.get('m_flHealFixed', {})
+                parsed_data['AOEHealthPickup'] = {
+                    'AOERadius': convert_engine_units_to_meters(pickup_data.get('m_flAOERadius')),
+                    'PickupRadiusBase': convert_engine_units_to_meters(pickup_radius.get('m_flBase')),
+                    'PickupRadiusScaling': convert_engine_units_to_meters(pickup_radius.get('m_flPerMinuteAfterStart')),
+                    'PickupRadiusMax': convert_engine_units_to_meters(pickup_radius.get('m_flMaxValue')),
+                    'PickupRadiusStartMinute': pickup_radius.get('m_flStartMinute'),
+                    'MissingPctRegen': pickup_data.get('m_flMissingPctRegen', {}).get('m_flBase'),
+                    'RegenFixed': regen_fixed.get('m_flBase'),
+                    'RegenFixedScaling': regen_fixed.get('m_flPerMinuteAfterStart'),
+                    'RegenDuration': pickup_data.get('m_flRegenDuration'),
+                    'RegenDurationTroopers': pickup_data.get('m_flRegenDurationTroopers'),
+                    'RegenTrooperMultiplier': pickup_data.get('m_flRegenTrooperMulti'),
+                    'RegenHPS': pickup_data.get('m_flRegenHPS'),
+                    'HealFixed': heal_fixed.get('m_flBase'),
+                    'HealFixedScaling': heal_fixed.get('m_flPerMinuteAfterStart'),
+                    'PickupExpirationDurationBase': expiration_duration.get('m_flBase'),
+                    'PickupExpirationDurationScaling': expiration_duration.get('m_flPerMinuteAfterStart'),
+                    'PickupExpirationDurationMax': expiration_duration.get('m_flMaxValue'),
+                    'PickupExpirationStartMinute': expiration_duration.get('m_flStartMinute'),
+                    'SameTeamOnly': pickup_data.get('m_bSameTeamOnly'),
+                }


### PR DESCRIPTION
The health pickup stats are already in `misc-data`, but having them appear directly under `trooper_medic` in `npc-data.json` will make them easier to find and use on the wiki.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/230) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_