### PR TITLE
feat: parse hero bullet radius into BulletRadius field

### DIFF
--- a/src/parser/parsers/weapon_parser.py
+++ b/src/parser/parsers/weapon_parser.py
@@ -28,6 +28,7 @@ def parse_weapon_info(weapon_info: Dict[str, Any]) -> Dict[str, Any]:
 
     # Bullet Properties
     stats['BulletGravityScale'] = weapon_info.get('m_flBulletGravityScale', 0)
+    stats['BulletRadius'] = convert_engine_units_to_meters(weapon_info.get('m_flBulletRadius', 0))
     stats['BulletsPerShot'] = weapon_info.get('m_iBullets', 1)
     stats['BulletsPerBurst'] = weapon_info.get('m_iBurstShotCount', 1)
     stats['BurstInterShotInterval'] = weapon_info.get('m_flIntraBurstCycleTime', 0)


### PR DESCRIPTION
Exposes `m_flBulletRadius` from each hero's weapon ability data as `BulletRadius` (in meters) in the hero weapon stats output.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/242) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_