### PR TITLE
feat: upload map image assets to the wiki

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -296,9 +296,9 @@ class Parser:
             json_utils.write(os.path.join(self.OUTPUT_DIR, 'json/midtown-metadata.json'), map_data['midtown']['metadata'])
 
             os.makedirs(os.path.join(self.OUTPUT_DIR, 'assets'), exist_ok=True)
-            map_data['midtown']['plots']['golden_statues'].save(os.path.join(self.OUTPUT_DIR, 'assets/golden-statues-map.png'))
-            map_data['midtown']['plots']['crate'].save(os.path.join(self.OUTPUT_DIR, 'assets/crate-map.png'))
-            map_data['midtown']['plots']['shops'].save(os.path.join(self.OUTPUT_DIR, 'assets/shops-map.png'))
+            map_data['midtown']['plots']['golden_statues'].save(os.path.join(self.OUTPUT_DIR, 'assets/golden_statues_map.png'))
+            map_data['midtown']['plots']['crate'].save(os.path.join(self.OUTPUT_DIR, 'assets/crate_map.png'))
+            map_data['midtown']['plots']['shops'].save(os.path.join(self.OUTPUT_DIR, 'assets/shops_map.png'))
 
     def _generate_resource_lookup(self, parsed_heroes, parsed_abilities, parsed_items):
         logger.trace('Generating resource lookup...')

--- a/src/wiki/pages.py
+++ b/src/wiki/pages.py
@@ -47,6 +47,14 @@ DATA_PAGE_FILE_MAP = {
     'Convars.json': 'json/convars.json',
 }
 
+# Maps file name in "File:" namespace on the wiki to
+# the file path in $OUTPUT_DIR
+IMAGE_FILE_MAP = {
+    'Golden_statues_map.png': 'assets/golden_statues_map.png',
+    'Crate_map.png': 'assets/crate_map.png',
+    'Shops_map.png': 'assets/shops_map.png',
+}
+
 # Ignore these pages as they are not automated
 IGNORE_PAGES = [
     'Dictionary',

--- a/src/wiki/upload.py
+++ b/src/wiki/upload.py
@@ -5,7 +5,7 @@ import re
 from datetime import datetime
 from typing import List, Tuple
 from utils import json_utils, game_utils, meta_utils
-from .pages import DATA_PAGE_FILE_MAP, IGNORE_PAGES
+from .pages import DATA_PAGE_FILE_MAP, IGNORE_PAGES, IMAGE_FILE_MAP
 from loguru import logger
 from . import changelog_utils
 
@@ -49,6 +49,7 @@ class WikiUpload:
     def run(self):
         logger.info(f'Uploading Data to Wiki - {self.upload_message}')
         self._update_data_pages()
+        self._upload_assets()
         self.wiki_updates = self._get_existing_update_pages()
         self._upload_changelog_pages()
         self._process_hotfixes()
@@ -214,6 +215,31 @@ class WikiUpload:
 
             json_string = json.dumps(data, indent=4)
             self._update_page(page, json_string)
+
+    def _upload_assets(self):
+        assets_dir = os.path.join(self.OUTPUT_DIR, 'assets')
+        if not os.path.isdir(assets_dir):
+            logger.trace(f'Assets directory not found at "{assets_dir}", skipping asset upload.')
+            return
+
+        logger.info('Uploading asset files...')
+        for wiki_filename, file_path in IMAGE_FILE_MAP.items():
+            full_path = os.path.join(self.OUTPUT_DIR, file_path)
+            if not os.path.isfile(full_path):
+                logger.warning(f'Asset file not found: {full_path}')
+                continue
+
+            page_title = f'File:{wiki_filename}'
+            logger.info(f'Uploading file: "{page_title}" from {full_path}')
+            if self.dry_run:
+                continue
+
+            try:
+                with open(full_path, 'rb') as f:
+                    self.site.upload(f, filename=wiki_filename, comment=self.upload_message, ignore=True)
+                logger.success(f'Successfully uploaded file "{page_title}"')
+            except Exception as e:
+                logger.error(f'Failed to upload file "{page_title}": {e}')
 
     def upload_new_page(self, title, content):
         """


### PR DESCRIPTION
Uploads the three map plot images (golden statues, crate locations, shop locations) generated by the map parser to the wiki File namespace.

Adds a `--force-asset-upload` flag that can be toggled via workflow dispatch to re-upload existing images when map data changes.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/246) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_