### PR TITLE
feat: add extra weapon and gravity attributes to attribute-data.json

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -145,6 +145,9 @@ ATTRIBUTE_MANUAL_MAP = {
         'label': 'StatDesc_SpiritLifestealEffectiveness',
         'postfix': 'StatDesc_SpiritLifestealEffectiveness_postfix',
     },
+    'GravityChange': {'label': 'GravityScale_label', 'postfix': 'GravityScale_postfix'},
+    'FalloffStartRange': {'postfix': 'StatDesc_WeaponRangeFalloffMin_postfix'},
+    'FalloffEndRange': {'postfix': 'StatDesc_WeaponRangeFalloffMax_postfix'},
 }
 
 

--- a/src/parser/parsers/attributes.py
+++ b/src/parser/parsers/attributes.py
@@ -45,6 +45,14 @@ class AttributeParser:
         all_attributes['Vitality']['GroundDashSpeed'] = {}
         all_attributes['Vitality']['AirDashSpeed'] = {}
 
+        # Manually add other weapon stats not exposed in m_ShopStatDisplay
+        all_attributes['Weapon']['BulletRadius'] = {}
+        all_attributes['Weapon']['FalloffStartRange'] = {}
+        all_attributes['Weapon']['FalloffEndRange'] = {}
+
+        # Manually add GravityChange to Vitality (extracted from modifier_hero_gravity)
+        all_attributes['Vitality']['GravityChange'] = {}
+
         # Determine the unlocalized name of each attribute that they should map to
         all_attributes.update(self._map_to_unlocalized(all_attributes))
 


### PR DESCRIPTION
Add BulletRadius, FalloffStartRange, FalloffEndRange to the Weapon category and GravityChange to the Vitality category in attribute-data.json.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/247) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_