### PR TITLE
ci: added repository dispatch to auto-deploy

### DIFF
--- a/.github/workflows/auto-deploy.yaml
+++ b/.github/workflows/auto-deploy.yaml
@@ -1,6 +1,9 @@
 name: Auto Deploy
 
 on:
+  schedule:
+    - cron: '23 * * * *'
+
   repository_dispatch:
     types: [cfw-deadlock-updated]
 

--- a/.github/workflows/auto-deploy.yaml
+++ b/.github/workflows/auto-deploy.yaml
@@ -1,8 +1,8 @@
 name: Auto Deploy
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  repository_dispatch:
+    types: [cfw-deadlock-updated]
 
   workflow_dispatch:
     inputs:
@@ -16,33 +16,11 @@ on:
         default: false
 
 jobs:
-  check-commit:
-    name: Check for new commit to SteamDB repo
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.compare.outputs.changed }}
-      latest_commit_sha: ${{ steps.remote_shas.outputs.steamdb_sha }}
-    steps:
-      - name: Get latest remote commit hashes
-        id: remote_shas
-        run: |
-          steamdb_sha=$(git ls-remote https://github.com/SteamDatabase/GameTracking-Deadlock.git HEAD | cut -f1)
-          echo "steamdb_sha=$steamdb_sha" >> "$GITHUB_OUTPUT"
-
-      - name: Compare against last known commits
-        id: compare
-        run: |
-          if [ "${{ steps.remote_shas.outputs.steamdb_sha }}" != "${{ vars.LAST_STEAMDB_SHA }}" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
   check-version:
     name: Check if deadlock version changed
     runs-on: ubuntu-latest
-    needs: check-commit
-    if: ${{ needs.check-commit.outputs.changed == 'true' || github.event.inputs.force == 'true' }}
+    # force will trigger deploy jobs regardless, so no point checking version
+    if: ${{ github.event.inputs.force == 'false' }}
     outputs:
       new_version: ${{ steps.check_version.outputs.new_version }}
     steps:
@@ -119,26 +97,3 @@ jobs:
       STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
       STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
       BOT_WIKI_PASS: ${{ secrets.BOT_WIKI_PASS }}
-
-  save-variables:
-    name: Save variables for next run
-    runs-on: ubuntu-latest
-    needs: [check-commit, deploy-develop, deploy-master]
-    if: >-
-      ${{
-        always() &&
-        needs.check-commit.outputs.changed == 'true' &&
-        needs.deploy-develop.result != 'failure' &&
-        needs.deploy-develop.result != 'cancelled' &&
-        needs.deploy-master.result != 'failure' &&
-        needs.deploy-master.result != 'cancelled'
-      }}
-    steps:
-      - name: Checkout Deadbot repo
-        uses: actions/checkout@v6
-
-      - name: Save latest SteamDB commit sha as a repo variable
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          gh variable set LAST_STEAMDB_SHA -b "${{ needs.check-commit.outputs.latest_commit_sha }}"


### PR DESCRIPTION


_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/253) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_