### PR TITLE
feat: added scaling data for Duration/Range/Charges

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 TARGET_TYPE_MAP = {
     'CITADEL_UNIT_TARGET_ALL_ENEMY': 'AllEnemy',
     'CITADEL_UNIT_TARGET_ALL_FRIENDLY': 'AllFriendly',
@@ -235,28 +237,6 @@ SCALE_TYPE_MAP = {
     'EWeaponPower': 'weapon_power',
 }
 
-# Scale types the game files use that are of no interest to the wiki, either because they only
-# apply to data we do not export, such as items and weapon sets, or because they say nothing
-# beyond what the attribute itself already does. Listing them keeps get_scale_type free to
-# raise on a scale type that is genuinely new to us
-IGNORED_SCALE_TYPES = {
-    'EAirMoveDistanceScale',
-    'EBuildUpRate',
-    'EChannelDuration',
-    'EClipSizeIncrease',
-    'EDamageScale',
-    'EItemCooldown',
-    'EMeleeRange',
-    'EProcBuildUpRateScale',
-    'EReloadSpeed',
-    'ETechDamageScale',
-    'EWeaponFalloffMaxRange',
-}
-
-
-def is_ignored_scale_type(scale):
-    return scale in IGNORED_SCALE_TYPES
-
 
 def class_to_scale_type(class_str: str) -> str | None:
     """
@@ -307,12 +287,27 @@ def class_to_scale_enum(class_str: str) -> str | None:
     return None
 
 
+# Scale types met that SCALE_TYPE_MAP has no entry for, tracked so each is only reported once
+_unmapped_scale_types = set()
+
+
 def get_scale_type(scale):
+    """
+    Get the wiki's name for a scale type, or None for one we have no mapping for
+
+    The game files hold plenty of scale types that the wiki has no use for, and a patch is free
+    to introduce more, so an unmapped type is dropped rather than raising. Each is reported once
+    so it can be added to SCALE_TYPE_MAP if it turns out to be worth exporting
+    """
     if scale is None:
         return scale
 
     if scale not in SCALE_TYPE_MAP:
-        raise Exception(f'No scale map found for {scale}')
+        if scale not in _unmapped_scale_types:
+            _unmapped_scale_types.add(scale)
+            logger.trace(f'No scale map found for {scale}, ignoring it. Add it to SCALE_TYPE_MAP if the wiki needs it')
+
+        return None
 
     return SCALE_TYPE_MAP[scale]
 

--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -216,35 +216,46 @@ def override_localization(attr):
 
 
 SCALE_TYPE_MAP = {
-    'EAirMoveDistanceScale': 'air_move_distance',
     'EBaseWeaponDamageIncrease': 'weapon_damage_increase',
-    'EBuildUpRate': 'build_up_rate',
     'EBulletDamage': 'damage',
-    'EChannelDuration': 'channel_duration',
-    'EClipSizeIncrease': 'clip_size',
-    'EDamageScale': 'damage_scale',
     'EHealingOutput': 'healing',
     'EHeavyMeleeDamage': 'heavy_melee',
-    'EItemCooldown': 'item_cooldown',
     'ELevelUpBoons': 'power_increase',
     'ELightMeleeDamage': 'melee',
     'EMaxChargesIncrease': 'max_charges',
-    'EMeleeRange': 'melee_range',
     'EParryCooldown': 'parry_cd',
-    'EProcBuildUpRateScale': 'proc_build_up_rate',
-    'EReloadSpeed': 'reload_speed',
     'EStatsCount': 'stats_count',
     'ETechCooldown': 'cooldown',
     'ETechCooldownBetweenChargeUses': 'charge_cooldown',
-    'ETechDamageScale': 'spirit_damage',
     'ETechDuration': 'duration',
     'ETechPower': 'spirit',
     'ETechRadius': 'radius',
     'ETechRange': 'range',
     'EWeaponDamageScale': 'weapon_damage',
-    'EWeaponFalloffMaxRange': 'weapon_falloff_range',
     'EWeaponPower': 'weapon_power',
 }
+
+# Scale types the game files use that are of no interest to the wiki, either because they only
+# apply to data we do not export, such as items and weapon sets, or because they say nothing
+# beyond what the attribute itself already does. Listing them keeps get_scale_type free to
+# raise on a scale type that is genuinely new to us
+IGNORED_SCALE_TYPES = {
+    'EAirMoveDistanceScale',
+    'EBuildUpRate',
+    'EChannelDuration',
+    'EClipSizeIncrease',
+    'EDamageScale',
+    'EItemCooldown',
+    'EMeleeRange',
+    'EProcBuildUpRateScale',
+    'EReloadSpeed',
+    'ETechDamageScale',
+    'EWeaponFalloffMaxRange',
+}
+
+
+def is_ignored_scale_type(scale):
+    return scale in IGNORED_SCALE_TYPES
 
 
 def class_to_scale_type(class_str: str) -> str | None:

--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -216,20 +216,33 @@ def override_localization(attr):
 
 
 SCALE_TYPE_MAP = {
+    'EAirMoveDistanceScale': 'air_move_distance',
     'EBaseWeaponDamageIncrease': 'weapon_damage_increase',
+    'EBuildUpRate': 'build_up_rate',
     'EBulletDamage': 'damage',
+    'EChannelDuration': 'channel_duration',
+    'EClipSizeIncrease': 'clip_size',
+    'EDamageScale': 'damage_scale',
     'EHealingOutput': 'healing',
     'EHeavyMeleeDamage': 'heavy_melee',
+    'EItemCooldown': 'item_cooldown',
     'ELevelUpBoons': 'power_increase',
     'ELightMeleeDamage': 'melee',
     'EMaxChargesIncrease': 'max_charges',
+    'EMeleeRange': 'melee_range',
     'EParryCooldown': 'parry_cd',
+    'EProcBuildUpRateScale': 'proc_build_up_rate',
+    'EReloadSpeed': 'reload_speed',
     'EStatsCount': 'stats_count',
     'ETechCooldown': 'cooldown',
+    'ETechCooldownBetweenChargeUses': 'charge_cooldown',
+    'ETechDamageScale': 'spirit_damage',
     'ETechDuration': 'duration',
     'ETechPower': 'spirit',
+    'ETechRadius': 'radius',
     'ETechRange': 'range',
     'EWeaponDamageScale': 'weapon_damage',
+    'EWeaponFalloffMaxRange': 'weapon_falloff_range',
     'EWeaponPower': 'weapon_power',
 }
 
@@ -252,8 +265,9 @@ def class_to_scale_type(class_str: str) -> str | None:
             'tech_duration': 'ETechDuration',
             'tech_cooldown': 'ETechCooldown',
             'weapon_damage': 'EWeaponDamageScale',
+            'base_weapon_damage': 'EBaseWeaponDamageIncrease',
             'ability_charges': 'EMaxChargesIncrease',
-            'ability_recharge_time': 'ETechCooldown',  # cooldown between charges
+            'ability_recharge_time': 'ETechCooldownBetweenChargeUses',
             'healing_spirit_scale': 'ETechPower',
             'healing_boon_scale': 'ELevelUpBoons',
         }

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -9,6 +9,10 @@ from loguru import logger
 # Scale applied to a stat when the game files do not specify one
 DEFAULT_STAT_SCALE = 1
 
+# Values that mark an attribute as not applying to the ability, eg. an ability without charges
+# still carries an AbilityCooldownBetweenCharge, set to -1
+INACTIVE_STAT_VALUES = (0, -1)
+
 
 class AbilityParser:
     def __init__(self, abilities_data, heroes_data, localizations):
@@ -90,17 +94,33 @@ class AbilityParser:
         if scale_func.get('m_bFunctionDisabled'):
             return
 
-        # an attribute of zero stays zero no matter how the hero's duration, range or cooldown
-        # scale it, so leave it as a plain zero for the output to strip
-        if num_utils.is_zero(value) and 'm_flStatScale' not in scale_func:
+        scale_stats = self._get_scale_stats(scale_func)
+
+        # an attribute that does not apply to the ability gains nothing from a stat that scales it
+        # at the default rate, so keep only a scale that the game files explicitly specify. That
+        # scale belongs to the first stat, the rest all scale at the default rate
+        if self._is_inactive_stat(value):
+            scale_stats = scale_stats[:1] if 'm_flStatScale' in scale_func else []
+
+        if not scale_stats:
             return
 
-        scales = [{'Value': scale_value, 'Type': maps.get_scale_type(scale_type)} for scale_type, scale_value in self._get_scale_stats(scale_func)]
+        scales = [{'Value': scale_value, 'Type': maps.get_scale_type(scale_type)} for scale_type, scale_value in scale_stats]
 
         if len(scales) == 1:
             return scales[0]
 
         return scales
+
+    def _is_inactive_stat(self, value):
+        """
+        Whether an attribute's value marks it as not applying to the ability, eg. an ability
+        without charges still carries an AbilityCooldownBetweenCharge, set to -1
+        """
+        if isinstance(value, bool):
+            return False
+
+        return value in INACTIVE_STAT_VALUES
 
     def _get_scale_stats(self, scale_func):
         """

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -6,6 +6,9 @@ from .upgrades import parse_upgrades
 from .modifiers import parse_modifiers
 from loguru import logger
 
+# Scale applied to a stat when the game files do not specify one
+DEFAULT_STAT_SCALE = 1
+
 
 class AbilityParser:
     def __init__(self, abilities_data, heroes_data, localizations):
@@ -50,7 +53,7 @@ class AbilityParser:
         for key in stats:
             stat = stats[key]
             value = self._get_stat_value(key, stat)
-            scale = self._get_scale(stat)
+            scale = self._get_scale(stat, value)
             if scale:
                 ability_data[key] = {'Value': value, 'Scale': scale}
             else:
@@ -72,31 +75,65 @@ class AbilityParser:
 
         return utils.convert_stat(stat, key, value)
 
-    def _get_scale(self, stat):
+    def _get_scale(self, stat, value):
         """
         Get scale data for the ability attribute, which will refer to how the value of the attribute
-        scales with another stat, usually Spirit
+        scales with another stat, such as Spirit, Ability Duration, Range or Cooldown
+
+        Returns a single scale, or a list of them when the attribute scales with several stats
         """
-        if 'm_subclassScaleFunction' not in stat:
-            return
-        scale = stat['m_subclassScaleFunction']
-        if 'm_flStatScale' not in scale:
+        scale_func = stat.get('m_subclassScaleFunction')
+        if not isinstance(scale_func, dict):
             return
 
-        scale_type = scale.get('m_eSpecificStatScaleType')
-        human_type = None
-        if scale_type:
-            human_type = maps.get_scale_type(scale_type)
-        else:
-            # Fallback: infer from _class
-            class_str = scale.get('_class', '')
-            if class_str:
-                human_type = maps.class_to_scale_type(class_str)
-            if not human_type:
-                # Last resort: default to spirit
-                human_type = maps.get_scale_type('ETechPower')
+        # Valve disables a scale function in place rather than removing it
+        if scale_func.get('m_bFunctionDisabled'):
+            return
 
-        return {
-            'Value': scale['m_flStatScale'],
-            'Type': human_type,
-        }
+        # an attribute of zero stays zero no matter how the hero's duration, range or cooldown
+        # scale it, so leave it as a plain zero for the output to strip
+        if num_utils.is_zero(value) and 'm_flStatScale' not in scale_func:
+            return
+
+        scales = [{'Value': scale_value, 'Type': maps.get_scale_type(scale_type)} for scale_type, scale_value in self._get_scale_stats(scale_func)]
+
+        if len(scales) == 1:
+            return scales[0]
+
+        return scales
+
+    def _get_scale_stats(self, scale_func):
+        """
+        Work out which of the hero's stats an ability attribute grows with, and at what rate each
+        of them applies
+
+        One attribute can grow with several hero stats at once, which the game files describe
+        across three fields:
+          - `m_eSpecificStatScaleType` names a single hero stat, eg. ETechPower for Spirit Power
+          - `m_flStatScale` is the rate the attribute grows at per point of that named stat, and
+            of no other. It is left out when the rate is 1, ie. the hero's stat applies in full
+          - `m_vecScalingStats` lists every hero stat involved, the named one included. All the
+            others apply in full
+
+        Lash's Death Slam uses all three. Its throw distance names ETechPower at a rate of 0.14
+        and lists [ETechPower, ETechRange], meaning the distance grows by 0.14 for every point of
+        Spirit Power, and on top of that grows in full with the hero's Ability Range. So it
+        returns [(ETechPower, 0.14), (ETechRange, 1)].
+
+        The named stat is returned first, being the one whose rate the game bothered to spell
+        out, and so the one a description is most likely to quote.
+        """
+        named_stat = scale_func.get('m_eSpecificStatScaleType') or maps.class_to_scale_enum(scale_func.get('_class', ''))
+        listed_stats = [scale_type for scale_type in scale_func.get('m_vecScalingStats') or [] if scale_type]
+
+        if not named_stat:
+            # with no stat named, the rate belongs to the first stat listed, falling back to
+            # spirit as it is by far the most common stat for an attribute to grow with
+            named_stat = listed_stats[0] if listed_stats else 'ETechPower'
+
+        named_rate = num_utils.assert_number(scale_func.get('m_flStatScale', DEFAULT_STAT_SCALE))
+
+        stats = [(named_stat, named_rate)]
+        stats += [(scale_type, DEFAULT_STAT_SCALE) for scale_type in listed_stats if scale_type != named_stat]
+
+        return stats

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -149,16 +149,27 @@ class AbilityParser:
 
         The named stat is returned first, being the one whose rate the game bothered to spell
         out, and so the one a description is most likely to quote.
+
+        Returns nothing when the scale function identifies no stat at all, which the game files
+        are full of, eg. a bare `{}` left behind on an attribute that does not grow with anything
         """
         named_stat = scale_func.get('m_eSpecificStatScaleType') or maps.class_to_scale_enum(scale_func.get('_class', ''))
         listed_stats = [scale_type for scale_type in scale_func.get('m_vecScalingStats') or [] if scale_type]
+        rate = scale_func.get('m_flStatScale')
 
         if not named_stat:
-            # with no stat named, the rate belongs to the first stat listed, falling back to
-            # spirit as it is by far the most common stat for an attribute to grow with
-            named_stat = listed_stats[0] if listed_stats else 'ETechPower'
+            if listed_stats:
+                # with no stat named, the rate belongs to the first stat listed
+                named_stat = listed_stats[0]
+            elif rate is None:
+                # nothing names a stat and no rate was given either, so there is no scaling here
+                return []
+            else:
+                # a rate on its own means the attribute definitely grows with something, and
+                # spirit is both the most common stat and the one rates are usually spelled out for
+                named_stat = 'ETechPower'
 
-        named_rate = num_utils.assert_number(scale_func.get('m_flStatScale', DEFAULT_STAT_SCALE))
+        named_rate = num_utils.assert_number(DEFAULT_STAT_SCALE if rate is None else rate)
 
         stats = [(named_stat, named_rate)]
         stats += [(scale_type, DEFAULT_STAT_SCALE) for scale_type in listed_stats if scale_type != named_stat]

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -102,12 +102,17 @@ class AbilityParser:
         if self._is_inactive_stat(value):
             scale_stats = scale_stats[:1] if 'm_flStatScale' in scale_func else []
 
-        scale_stats = [(scale_type, scale_value) for scale_type, scale_value in scale_stats if not maps.is_ignored_scale_type(scale_type)]
+        scales = []
+        for scale_type, scale_value in scale_stats:
+            human_type = maps.get_scale_type(scale_type)
+            # scale types the wiki has no mapping for are dropped, see get_scale_type
+            if human_type is None:
+                continue
 
-        if not scale_stats:
+            scales.append({'Value': scale_value, 'Type': human_type})
+
+        if not scales:
             return
-
-        scales = [{'Value': scale_value, 'Type': maps.get_scale_type(scale_type)} for scale_type, scale_value in scale_stats]
 
         if len(scales) == 1:
             return scales[0]

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -102,6 +102,8 @@ class AbilityParser:
         if self._is_inactive_stat(value):
             scale_stats = scale_stats[:1] if 'm_flStatScale' in scale_func else []
 
+        scale_stats = [(scale_type, scale_value) for scale_type, scale_value in scale_stats if not maps.is_ignored_scale_type(scale_type)]
+
         if not scale_stats:
             return
 

--- a/src/parser/parsers/ability_cards.py
+++ b/src/parser/parsers/ability_cards.py
@@ -535,25 +535,11 @@ class AbilityCardsParser:
             if token_override is not None:
                 overrides[token_override] = value
 
-        # take a copy to prevent modifying the output data
-        format_data = data.copy()
-
-        # For a Scale, map the base and scale values to separate variables for description formatting
-        for attr, value in data.items():
-            if isinstance(value, dict) and 'Scale' in value:
-                format_data[attr] = value['Value']
-
-                # if there are multiple scales, use the first one as it is usually the more relevant one - eg. spirit power
-                if isinstance(value['Scale'], list):
-                    format_data[f'{attr}_scale'] = value['Scale'][0]['Value']
-                else:
-                    format_data[f'{attr}_scale'] = value['Scale']['Value']
-
         # required variables to insert into the description
         format_vars = (
             self.ability,
             overrides,
-            format_data,
+            data,
             {'ability_key': self.ability_index},
             {'hero_name': self.hero['Name']},
             self.localizations[self.language],

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -172,13 +172,14 @@ class ItemParser:
             return None
 
         scale_type = scale_func.get('m_eSpecificStatScaleType')
-        human_type = get_scale_type(scale_type) if scale_type else None
-
-        # Fallback to inferring from _class
-        if not human_type:
-            class_str = scale_func.get('_class', '')
-            if class_str:
-                human_type = maps.class_to_scale_type(class_str)
+        if scale_type:
+            human_type = get_scale_type(scale_type)
+            # a named scale type that the wiki has no mapping for is dropped rather than guessed at
+            if human_type is None:
+                return None
+        else:
+            # Fallback to inferring from _class
+            human_type = maps.class_to_scale_type(scale_func.get('_class', ''))
             if not human_type:
                 human_type = maps.get_scale_type('ETechPower')
 

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -28,6 +28,19 @@ def format_description(description, *data_sets):
     for data_set in data_sets:
         data.update(data_set)
 
+    # a scaled attribute nests its number under 'Value', eg. {'Value': 6, 'Scale': {...}}.
+    # A description wants that number, with the scale offered separately as '<attr>_scale'
+    for key, value in list(data.items()):
+        if isinstance(value, dict) and 'Scale' in value:
+            data[key] = value['Value']
+
+            scale = value['Scale']
+            # if there are multiple scales, use the first one as it is usually the more relevant one - eg. spirit power
+            if isinstance(scale, list):
+                scale = scale[0]
+
+            data[f'{key}_scale'] = scale['Value']
+
     if isinstance(description, tuple):
         description = description[0]
 


### PR DESCRIPTION
Added parsing scaling for ability range, duration, radius, and some other types which were ignored before because they're living in another field.

Example changes can be seen in the attached deadbot/data PR.

---

This introduces a couple of risky changes to ability-data.json and ability-cards.json
- Some fields go from being flat `"AbilityDuration": 25` to nested `"AbilityDuration": {"Value": ..., "Scale": ...}`.
- Scalings can now be arrays. For example, Doorman's Doorway scales with both SP and Range. Previously Range was ignored, now it is included.

I've already tested the changes by hand patching changes onto live wiki and fixing modules that were not prepared for that, but wanted to note anyway.

---

Another note, this PR does not touch items (which also often scale with ability range and duration), as I didn't want to increase risk further. Items can get a similar addition in the future.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/258) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_