### PR TITLE
fix: stop exporting the stats_count as a scale type

### DIFF
--- a/src/parser/maps.py
+++ b/src/parser/maps.py
@@ -226,7 +226,6 @@ SCALE_TYPE_MAP = {
     'ELightMeleeDamage': 'melee',
     'EMaxChargesIncrease': 'max_charges',
     'EParryCooldown': 'parry_cd',
-    'EStatsCount': 'stats_count',
     'ETechCooldown': 'cooldown',
     'ETechCooldownBetweenChargeUses': 'charge_cooldown',
     'ETechDuration': 'duration',
@@ -285,6 +284,20 @@ def class_to_scale_enum(class_str: str) -> str | None:
         if human == human_type:
             return enum_key
     return None
+
+
+# The stats enum ends with EStatsCount and EStatsInvalid, which share the value 98, and
+# m_eSpecificStatScaleType defaults to it. A scale function carrying it names no stat at all
+UNSET_SCALE_TYPES = ('EStatsCount', 'EStatsInvalid')
+
+
+def get_specific_scale_type(scale_func):
+    """Read the stat that a scale function names, treating the enum's unset value as naming none"""
+    scale_type = scale_func.get('m_eSpecificStatScaleType')
+    if not scale_type or scale_type in UNSET_SCALE_TYPES:
+        return None
+
+    return scale_type
 
 
 # Scale types met that SCALE_TYPE_MAP has no entry for, tracked so each is only reported once

--- a/src/parser/parsers/abilities/__main__.py
+++ b/src/parser/parsers/abilities/__main__.py
@@ -153,8 +153,10 @@ class AbilityParser:
         Returns nothing when the scale function identifies no stat at all, which the game files
         are full of, eg. a bare `{}` left behind on an attribute that does not grow with anything
         """
-        named_stat = scale_func.get('m_eSpecificStatScaleType') or maps.class_to_scale_enum(scale_func.get('_class', ''))
-        listed_stats = [scale_type for scale_type in scale_func.get('m_vecScalingStats') or [] if scale_type]
+        named_stat = maps.get_specific_scale_type(scale_func) or maps.class_to_scale_enum(scale_func.get('_class', ''))
+        listed_stats = [
+            scale_type for scale_type in scale_func.get('m_vecScalingStats') or [] if scale_type and scale_type not in maps.UNSET_SCALE_TYPES
+        ]
         rate = scale_func.get('m_flStatScale')
 
         if not named_stat:

--- a/src/parser/parsers/items.py
+++ b/src/parser/parsers/items.py
@@ -171,7 +171,7 @@ class ItemParser:
         if base_value_str is None:
             return None
 
-        scale_type = scale_func.get('m_eSpecificStatScaleType')
+        scale_type = maps.get_specific_scale_type(scale_func)
         if scale_type:
             human_type = get_scale_type(scale_type)
             # a named scale type that the wiki has no mapping for is dropped rather than guessed at


### PR DESCRIPTION
Rake's damage and Card Trick's diamond resist shred duration were both exported as scaling with "stats_count", which is not a hero stat at all.

EStatsType.h in decompiled files reads:
```
    EAbilityLevel = 97,
    EStatsCount = 98,
    EStatsInvalid = 98,
```
EStatsCount has same value as EStatsInvalid, so it's not a real scaling.

SCALE_TYPE_MAP had it mapped to an invented "stats_count", which wiki module later remaps into spirit so Rake can display its scaling.

---

In this PR reading this EStatsCount value falls back to reading `_class`  instead, which is where the real stat lives for both: Rake's scale function is a CScaleFunctionAbilityProperty_TechDamage, so its damage grows with spirit at the rate of 1.0 it already carried, and Card Trick's is a CScaleFunctionAbilityProperty_TechDuration, so its shred grows with ability duration, the same as ClubSlowDuration beside it.

Merging this will replace invented `stats_count` with real data and allow us to erase this weird `stats_count => spirit` on the wiki side.

_Parsed data in [deadlock-data PR](https://github.com/deadlock-wiki/deadlock-data/pull/262) - Reopen deadbot PR or run deploy workflow for this branch [here](https://github.com/deadlock-wiki/deadbot/actions/workflows/deploy.yaml) to reparse the data_